### PR TITLE
.gitignore - added CLion's temporary build directories (cmake-build*)…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@
 
 # Intermediates
 build/*
+cmake-build*
 
 # Ides
 .vscode/
+.idea


### PR DESCRIPTION
.gitignore - added CLion's temporary build directories (cmake-build*) as well as JetBrains IDE's .idea folder.