### PR TITLE
Fixes crash at startup related to height/width passed as 0 on screens with custom scaling

### DIFF
--- a/modules/yup_gui/native/yup_Windowing_glfw.cpp
+++ b/modules/yup_gui/native/yup_Windowing_glfw.cpp
@@ -632,8 +632,8 @@ void GLFWComponentNative::setBounds (const Rectangle<int>& newBounds)
         glfwGetWindowFrameSize (window, &leftMargin, &topMargin, &rightMargin, &bottomMargin);
 
     glfwSetWindowSize (window,
-                       jmax (0, newBounds.getWidth() - leftMargin - rightMargin),
-                       jmax (0, newBounds.getHeight() - topMargin - bottomMargin));
+                       jmax (1, newBounds.getWidth() - leftMargin - rightMargin),
+                       jmax (1, newBounds.getHeight() - topMargin - bottomMargin));
 
 #endif
 


### PR DESCRIPTION
This change fixes issue for me. 

![Screenshot 2024-09-20 at 2 23 28 PM](https://github.com/user-attachments/assets/0dd940d6-6d47-4e06-969c-e9823cf58b79)
![Screenshot 2024-09-20 at 2 23 14 PM](https://github.com/user-attachments/assets/73ed12c8-2b37-499b-aa81-c87cf5d42edf)
