### PR TITLE
Fix python tests relative paths

### DIFF
--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,3 +1,7 @@
-from . import common
+import sys
+from pathlib import Path
 
-import yup
+tests_folder = str(Path(__file__).parent)
+
+if tests_folder not in sys.path:
+    sys.path.insert(0, tests_folder)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,8 +1,15 @@
 import sys
+from pathlib import Path
+
 import pytest
 
-from . import common
-from .utilities import get_runtime_data_folder, remove_directory_recursively
+tests_folder = str(Path(__file__).parent)
+
+if tests_folder not in sys.path:
+    sys.path.insert(0, tests_folder)
+
+import common
+from utilities import get_runtime_data_folder, remove_directory_recursively
 
 import yup
 

--- a/python/tests/test_yup_core/__init__.py
+++ b/python/tests/test_yup_core/__init__.py
@@ -1,1 +1,1 @@
-from .. import common
+import common

--- a/python/tests/test_yup_core/test_File.py
+++ b/python/tests/test_yup_core/test_File.py
@@ -2,7 +2,7 @@ import os
 import sys
 import pytest
 
-from ..utilities import get_runtime_data_file
+from utilities import get_runtime_data_file
 import yup
 
 this_file = os.path.abspath(__file__)

--- a/python/tests/test_yup_core/test_FileFilter.py
+++ b/python/tests/test_yup_core/test_FileFilter.py
@@ -1,6 +1,6 @@
 import os
 
-from ..utilities import get_runtime_data_file
+from utilities import get_runtime_data_file
 import yup
 
 this_file = os.path.abspath(__file__)

--- a/python/tests/test_yup_core/test_FileOutputStream.py
+++ b/python/tests/test_yup_core/test_FileOutputStream.py
@@ -2,7 +2,7 @@ import os
 import textwrap
 import pytest
 
-from ..utilities import get_runtime_data_file
+from utilities import get_runtime_data_file
 import yup
 
 

--- a/python/tests/test_yup_core/test_JSON.py
+++ b/python/tests/test_yup_core/test_JSON.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..utilities import get_runtime_data_file
+from utilities import get_runtime_data_file
 import yup
 
 #==================================================================================================

--- a/python/tests/test_yup_core/test_TemporaryFile.py
+++ b/python/tests/test_yup_core/test_TemporaryFile.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 
-from ..utilities import get_runtime_data_file
+from utilities import get_runtime_data_file
 import yup
 
 #==================================================================================================

--- a/python/tests/test_yup_core/test_XmlElement.py
+++ b/python/tests/test_yup_core/test_XmlElement.py
@@ -2,7 +2,7 @@ import os
 import sys
 import pytest
 
-from ..utilities import get_runtime_data_folder
+from utilities import get_runtime_data_folder
 import yup
 
 

--- a/python/tests/test_yup_core/test_ZipFile.py
+++ b/python/tests/test_yup_core/test_ZipFile.py
@@ -4,7 +4,7 @@ import sys
 
 import yup
 
-from ..utilities import get_runtime_data_folder
+from utilities import get_runtime_data_folder
 
 
 #==================================================================================================

--- a/python/tests/test_yup_events/__init__.py
+++ b/python/tests/test_yup_events/__init__.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 
-from .. import common
+import common
 
 import yup
 

--- a/python/tests/test_yup_graphics/__init__.py
+++ b/python/tests/test_yup_graphics/__init__.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .. import common
+import common
 
 import yup
 

--- a/python/tests/utilities.py
+++ b/python/tests/utilities.py
@@ -1,7 +1,7 @@
 import os
 from pathlib import Path
 
-from . import common
+import common
 
 import yup
 


### PR DESCRIPTION
This pull request updates the import system throughout the `python/tests` directory to simplify and standardize how test modules import shared utilities and the `common` module. The main change is to ensure that test files can use direct imports instead of relative imports by adding the test folder to `sys.path` at runtime. This improves compatibility and avoids import errors when running tests.

Key changes:

**Import system modernization:**

* Added logic to `__init__.py` and `conftest.py` to insert the test folder into `sys.path` if not already present. This allows for direct imports of modules like `common` and `utilities` from anywhere in the test suite. [[1]](diffhunk://#diff-cd6265598da4c0736c0f9bf5f6f8c103dfebbd7a828afc419e8c448880cc7de5L1-R7) [[2]](diffhunk://#diff-93c4e2e1e5b9bad7dee0662cdcc293096d159ee95665affad7ea84814d2eb738R2-R12)

**Refactoring imports in test modules:**

* Replaced all relative imports (e.g., `from ..utilities import ...`) with direct imports (e.g., `from utilities import ...`) in test files in `test_yup_core`, `test_yup_events`, and `test_yup_graphics` subdirectories. This includes updates in files such as `test_File.py`, `test_FileFilter.py`, `test_FileOutputStream.py`, `test_JSON.py`, `test_TemporaryFile.py`, `test_XmlElement.py`, and `test_ZipFile.py`. [[1]](diffhunk://#diff-d7018902b064db238580104166df8dcd8ac000f0f64e30b4adf9e4e137460fa2L1-R1) [[2]](diffhunk://#diff-0f494d6732ef23af8016bfc9dc3a84c034bf8c519aed11f4b7fe3aa43dd781dfL5-R5) [[3]](diffhunk://#diff-d2d5f6e0d231bf15a0418351697168c609e65e0cdcbedf4c255676dc0ba0745dL3-R3) [[4]](diffhunk://#diff-792f57941f655f4e7798fbfa67d10ac19d1dc5a796869cee90f0dddacef05687L5-R5) [[5]](diffhunk://#diff-4af7c562042188e928fe8e964615905b14552d15778f963106f1477fccd61c7cL3-R3) [[6]](diffhunk://#diff-b67cc29e79ec04d9907366e36acf46065e98d6f06c3dc2d6dcfe6c80e7cee698L4-R4) [[7]](diffhunk://#diff-eba9e8302c59067307cbf67a93c2cfad3cabd1489abc2c4f71266f79ee709061L5-R5) [[8]](diffhunk://#diff-e3dfbd93db69893bc398af9d1e0cae19334aec3ed083fcd66ed61ad2a7b2fd4aL7-R7) [[9]](diffhunk://#diff-3b6caf254924f0cc63b82d6bcad7cdceafe973ef18be95677d4cfed1331b2659L4-R4) [[10]](diffhunk://#diff-c63013d79bd020bcb435cdfa7be08c127698d8b9e2f07e546f45ca98a146fde7L3-R3) [[11]](diffhunk://#diff-329825b99d603e1dd89b44fae717c594b1fa489785b3a62f5a2ec1b8895e303dL4-R4)

These changes make the test suite more robust and easier to maintain by eliminating fragile relative imports and ensuring consistent module resolution.