### PR TITLE
Make sure we fail on yup modules circular deps

### DIFF
--- a/cmake/yup_audio_plugin.cmake
+++ b/cmake/yup_audio_plugin.cmake
@@ -72,6 +72,13 @@ function (yup_audio_plugin)
         return()
     endif()
 
+    set (target_modules "${YUP_ARG_MODULES}")
+    list (APPEND target_modules yup_audio_plugin_client)
+    if (YUP_ARG_PLUGIN_CREATE_STANDALONE)
+        list (APPEND target_modules yup_audio_devices)
+    endif()
+    _yup_module_check_circular_dependencies ("${target_name} audio plugin" "${target_modules}")
+
     # ==== Create static library for user's plugin code
     _yup_message (STATUS "Creating static library for user's plugin code")
     add_library (${target_name}_shared INTERFACE)

--- a/cmake/yup_modules.cmake
+++ b/cmake/yup_modules.cmake
@@ -427,6 +427,64 @@ endfunction()
 
 #==============================================================================
 
+function (_yup_module_normalize_dependency_target dependency output_variable)
+    set (normalized_dependency "${dependency}")
+
+    if (TARGET "${normalized_dependency}")
+        get_target_property (aliased_target "${normalized_dependency}" ALIASED_TARGET)
+        if (aliased_target)
+            set (normalized_dependency "${aliased_target}")
+        endif()
+    elseif ("${normalized_dependency}" MATCHES "^yup::(.+)$")
+        string (REGEX REPLACE "^yup::" "" normalized_dependency "${normalized_dependency}")
+    endif()
+
+    set (${output_variable} "${normalized_dependency}" PARENT_SCOPE)
+endfunction()
+
+#==============================================================================
+
+function (_yup_module_check_dependency_cycle module_name context_name active_stack)
+    _yup_module_normalize_dependency_target ("${module_name}" module_target)
+
+    if (NOT TARGET "${module_target}")
+        return()
+    endif()
+
+    get_target_property (module_path "${module_target}" YUP_MODULE_PATH)
+    if (NOT module_path)
+        return()
+    endif()
+
+    list (FIND active_stack "${module_target}" cycle_start)
+    if (NOT cycle_start EQUAL -1)
+        list (LENGTH active_stack active_stack_length)
+        math (EXPR cycle_length "${active_stack_length} - ${cycle_start}")
+        list (SUBLIST active_stack ${cycle_start} ${cycle_length} cycle_path)
+        list (APPEND cycle_path "${module_target}")
+        list (JOIN cycle_path " -> " cycle_message)
+
+        _yup_message (FATAL_ERROR "${context_name} introduces a circular YUP module dependency: ${cycle_message}")
+    endif()
+
+    list (APPEND active_stack "${module_target}")
+
+    get_target_property (module_dependencies "${module_target}" YUP_MODULE_DEPENDENCIES)
+    foreach (module_dependency IN LISTS module_dependencies)
+        _yup_module_check_dependency_cycle ("${module_dependency}" "${context_name}" "${active_stack}")
+    endforeach()
+endfunction()
+
+#==============================================================================
+
+function (_yup_module_check_circular_dependencies context_name module_targets)
+    foreach (module_target IN LISTS module_targets)
+        _yup_module_check_dependency_cycle ("${module_target}" "${context_name}" "")
+    endforeach()
+endfunction()
+
+#==============================================================================
+
 function (_yup_module_setup_target module_name
                                    module_path
                                    module_cpp_standard

--- a/cmake/yup_standalone.cmake
+++ b/cmake/yup_standalone.cmake
@@ -77,6 +77,9 @@ function (yup_standalone_app)
         return()
     endif()
 
+    # ==== Check for modules circular dependencies
+    _yup_module_check_circular_dependencies ("${target_name} standalone application" "${YUP_ARG_MODULES}")
+
     # ==== Find modules includes
     set (module_include_dirs "")
     foreach (module IN ITEMS ${YUP_ARG_MODULES})


### PR DESCRIPTION
This pull request introduces logic to detect and prevent circular dependencies between YUP modules at CMake configuration time. The main changes add helper functions to normalize dependency targets and recursively check for cycles, and integrate these checks into both plugin and standalone application build functions.

Dependency cycle detection:

* Added `_yup_module_normalize_dependency_target`, `_yup_module_check_dependency_cycle`, and `_yup_module_check_circular_dependencies` helper functions to `cmake/yup_modules.cmake`. These functions normalize dependency names, recursively check for circular dependencies, and emit a fatal error with a clear message if a cycle is detected.

Integration with build functions:

* Updated `yup_audio_plugin` in `cmake/yup_audio_plugin.cmake` to check for circular dependencies among specified modules (including `yup_audio_plugin_client` and optionally `yup_audio_devices`) before proceeding with plugin build steps.
* Updated `yup_standalone_app` in `cmake/yup_standalone.cmake` to check for circular dependencies among specified modules before proceeding with application build steps.