### PR TITLE
Spectral processor

### DIFF
--- a/examples/audiograph/source/AudioGraphApp.cpp
+++ b/examples/audiograph/source/AudioGraphApp.cpp
@@ -202,8 +202,10 @@ void AudioGraphApp::audioDeviceAboutToStart (yup::AudioIODevice* device)
     nodeRegistry.setPluginScanner (scanner.get(), ctx);
 #endif
 
-    graph->prepareToPlay (static_cast<float> (device->getCurrentSampleRate()),
-                          device->getCurrentBufferSizeSamples());
+    const auto spec = yup::AudioSpec (
+        static_cast<float> (device->getCurrentSampleRate()),
+        device->getCurrentBufferSizeSamples());
+    graph->prepareToPlay (spec);
 }
 
 void AudioGraphApp::audioDeviceStopped()

--- a/examples/audiograph/source/nodes/AnalyzerNodes.h
+++ b/examples/audiograph/source/nodes/AnalyzerNodes.h
@@ -155,7 +155,7 @@ public:
         analyzerState.setOverlapFactor (0.0f);
     }
 
-    void prepareToPlay (float, int) override
+    void prepareToPlay (const yup::AudioSpec&) override
     {
         analyzerState.reset();
         peakLevel.store (0.0f, std::memory_order_relaxed);
@@ -379,7 +379,7 @@ public:
         analyzerState.setOverlapFactor (0.5f);
     }
 
-    void prepareToPlay (float, int) override
+    void prepareToPlay (const yup::AudioSpec&) override
     {
         analyzerState.reset();
         peakLevel.store (0.0f, std::memory_order_relaxed);

--- a/examples/audiograph/source/nodes/DistortionNodes.h
+++ b/examples/audiograph/source/nodes/DistortionNodes.h
@@ -46,17 +46,17 @@ public:
         updateLatency();
     }
 
-    void prepareToPlay (float newSampleRate, int maxBlockSize) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
-        const auto sampleRate = yup::jmax (1.0f, newSampleRate);
-        const auto blockSize = yup::jmax (1, maxBlockSize);
+        const auto sampleRate = yup::jmax (1.0f, spec.sampleRate);
+        const auto blockSize = yup::jmax (1, spec.maxBlockSize);
 
         oversampler2x.prepare (sampleRate, maximumOversampledChannels, blockSize);
         oversampler4x.prepare (sampleRate, maximumOversampledChannels, blockSize);
         oversampler8x.prepare (sampleRate, maximumOversampledChannels, blockSize);
         oversamplersPrepared = true;
 
-        smoothedDrive.reset (newSampleRate, 0.02);
+        smoothedDrive.reset (sampleRate, 0.02);
         smoothedDrive.setCurrentAndTargetValue (getDrive());
 
         updateLatency();
@@ -279,14 +279,14 @@ public:
         addParameter (output);
     }
 
-    void prepareToPlay (float newSampleRate, int maxBlockSize) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
         for (auto& clipper : clippers)
-            clipper.prepare (newSampleRate, maxBlockSize);
+            clipper.prepare (spec.sampleRate, spec.maxBlockSize);
 
-        smoothedDrive.reset (newSampleRate, 0.02);
+        smoothedDrive.reset (spec.sampleRate, 0.02);
         smoothedDrive.setCurrentAndTargetValue (getDrive());
-        smoothedOutput.reset (newSampleRate, 0.02);
+        smoothedOutput.reset (spec.sampleRate, 0.02);
         smoothedOutput.setCurrentAndTargetValue (getOutput());
     }
 
@@ -592,14 +592,14 @@ public:
         addParameter (output);
     }
 
-    void prepareToPlay (float newSampleRate, int maxBlockSize) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
         for (auto& clipper : clippers)
-            clipper.prepare (static_cast<double> (newSampleRate), maxBlockSize);
+            clipper.prepare (static_cast<double> (spec.sampleRate), spec.maxBlockSize);
 
-        smoothedDrive.reset (newSampleRate, 0.02);
+        smoothedDrive.reset (spec.sampleRate, 0.02);
         smoothedDrive.setCurrentAndTargetValue (getDrive());
-        smoothedOutput.reset (newSampleRate, 0.02);
+        smoothedOutput.reset (spec.sampleRate, 0.02);
         smoothedOutput.setCurrentAndTargetValue (getOutput());
     }
 

--- a/examples/audiograph/source/nodes/FractionalDelayNode.h
+++ b/examples/audiograph/source/nodes/FractionalDelayNode.h
@@ -49,9 +49,9 @@ public:
         addParameter (dryWet);
     }
 
-    void prepareToPlay (float newSampleRate, int) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
-        sampleRate.store (yup::jmax (1.0f, newSampleRate), std::memory_order_relaxed);
+        sampleRate.store (yup::jmax (1.0f, spec.sampleRate), std::memory_order_relaxed);
 
         const int maxDelaySamples = yup::roundToInt (delayMillisecondsToSamples (maximumDelayMilliseconds));
         for (auto& delayLine : delayLines)

--- a/examples/audiograph/source/nodes/GainNode.h
+++ b/examples/audiograph/source/nodes/GainNode.h
@@ -36,9 +36,9 @@ public:
         addParameter (gain);
     }
 
-    void prepareToPlay (float newSampleRate, int) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
-        smoothedGain.reset (newSampleRate, 0.02);
+        smoothedGain.reset (spec.sampleRate, 0.02);
         smoothedGain.setCurrentAndTargetValue (getGain());
     }
 

--- a/examples/audiograph/source/nodes/LatencyNode.h
+++ b/examples/audiograph/source/nodes/LatencyNode.h
@@ -41,12 +41,12 @@ public:
         reportUpdatedLatency();
     }
 
-    void prepareToPlay (float newSampleRate, int maxBlockSize) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
-        sampleRate.store (yup::jmax (1.0f, newSampleRate), std::memory_order_relaxed);
+        sampleRate.store (yup::jmax (1.0f, spec.sampleRate), std::memory_order_relaxed);
 
         const int maxDelaySamples = delayMillisecondsToSamples (maximumDelayMilliseconds);
-        history.setSize (2, maxDelaySamples + yup::jmax (1, maxBlockSize) + 1);
+        history.setSize (2, maxDelaySamples + yup::jmax (1, spec.maxBlockSize) + 1);
         history.clear();
 
         writePosition = 0;

--- a/examples/audiograph/source/nodes/NodeRegistry.h
+++ b/examples/audiograph/source/nodes/NodeRegistry.h
@@ -36,6 +36,7 @@
 #include "PluginNodeView.h"
 #include "RecorderNode.h"
 #include "SamplePlayerNode.h"
+#include "SpectralPassthroughNode.h"
 #include "SubgraphNode.h"
 
 //==============================================================================
@@ -86,6 +87,9 @@ public:
 
     /** Stable factory key for the built-in recorder node. */
     static constexpr const char* recorderIdentifier = "internal.recorder";
+
+    /** Stable factory key for the built-in spectral passthrough node. */
+    static constexpr const char* spectralPassthroughIdentifier = "internal.spectralPassthrough";
 
     /** Stable factory key for the built-in recursive subgraph node. */
     static constexpr const char* subgraphIdentifier = "internal.subgraph";
@@ -302,6 +306,21 @@ public:
                 return nullptr;
 
             return std::make_unique<RecorderNodeView> (nodeID, *recorder);
+        }
+        };
+
+        entries[spectralPassthroughIdentifier] = {
+            [] (const yup::AudioGraphNodeProperties&) -> yup::ResultValue<std::unique_ptr<yup::AudioProcessor>>
+        {
+            return yup::makeResultValueOk (std::make_unique<SpectralPassthroughProcessor>());
+        },
+            [] (yup::AudioGraphNodeID nodeID, yup::AudioProcessor* proc, yup::AudioGraphProcessor*) -> std::unique_ptr<yup::AudioGraphNodeView>
+        {
+            auto* spectral = dynamic_cast<SpectralPassthroughProcessor*> (proc);
+            if (spectral == nullptr)
+                return nullptr;
+
+            return std::make_unique<SpectralPassthroughNodeView> (nodeID, *spectral);
         }
         };
 
@@ -528,6 +547,7 @@ public:
             oscilloscopeIdentifier,
             recorderIdentifier,
             samplePlayerIdentifier,
+            spectralPassthroughIdentifier,
             spectrumAnalyzerIdentifier,
             subgraphIdentifier,
             svfIdentifier,
@@ -580,6 +600,9 @@ public:
 
         if (id == recorderIdentifier)
             return "Recorder";
+
+        if (id == spectralPassthroughIdentifier)
+            return "Spectral Passthrough";
 
         if (id == subgraphIdentifier)
             return "Subgraph";

--- a/examples/audiograph/source/nodes/OscillatorNode.h
+++ b/examples/audiograph/source/nodes/OscillatorNode.h
@@ -41,9 +41,9 @@ public:
         addParameter (sweepEnabled);
     }
 
-    void prepareToPlay (float newSampleRate, int) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
-        sampleRate = newSampleRate;
+        sampleRate = spec.sampleRate;
         phase = 0.0;
         sweepPositionSeconds = 0.0;
         wasSweepActive = false;

--- a/examples/audiograph/source/nodes/RecorderNode.h
+++ b/examples/audiograph/source/nodes/RecorderNode.h
@@ -83,9 +83,9 @@ public:
         fifoBuffer.resize (fifoCapacity);
     }
 
-    void prepareToPlay (float sampleRate, int) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
-        currentSampleRate.store (sampleRate > 0.0f ? sampleRate : 44100.0f, std::memory_order_relaxed);
+        currentSampleRate.store (spec.sampleRate > 0.0f ? spec.sampleRate : 44100.0f, std::memory_order_relaxed);
     }
 
     void releaseResources() override {}

--- a/examples/audiograph/source/nodes/SamplePlayerNode.h
+++ b/examples/audiograph/source/nodes/SamplePlayerNode.h
@@ -46,9 +46,9 @@ public:
     {
     }
 
-    void prepareToPlay (float newSampleRate, int) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
-        playbackSampleRate.store (newSampleRate > 0.0f ? newSampleRate : 44100.0f, std::memory_order_relaxed);
+        playbackSampleRate.store (spec.sampleRate > 0.0f ? spec.sampleRate : 44100.0f, std::memory_order_relaxed);
     }
 
     void releaseResources() override {}

--- a/examples/audiograph/source/nodes/SpectralPassthroughNode.h
+++ b/examples/audiograph/source/nodes/SpectralPassthroughNode.h
@@ -1,0 +1,150 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include "NodeViewHelpers.h"
+
+//==============================================================================
+class SpectralPassthroughProcessor final : public yup::SpectralBridge
+{
+public:
+    SpectralPassthroughProcessor()
+        : SpectralBridge ("Spectral Passthrough",
+                          yup::AudioBusLayout ({ yup::AudioBus ("Main", yup::AudioBus::Audio, yup::AudioBus::Input, 2) },
+                                               { yup::AudioBus ("Main", yup::AudioBus::Audio, yup::AudioBus::Output, 2) }))
+    {
+        fftSizeIndex = NodeViewHelpers::createParameter ("fftSizeIndex", "FFT Size", 0.0f, 6.0f, 3.0f, 1.0f);
+        overlapFactorIndex = NodeViewHelpers::createParameter ("overlapFactorIndex", "Overlap", 0.0f, 2.0f, 1.0f, 1.0f);
+
+        addParameter (fftSizeIndex);
+        addParameter (overlapFactorIndex);
+
+        applySettings();
+    }
+
+    float getFFTSizeIndex() const noexcept { return fftSizeIndex->getValue(); }
+
+    float getOverlapFactorIndex() const noexcept { return overlapFactorIndex->getValue(); }
+
+    void setFFTSizeIndex (float v) noexcept
+    {
+        fftSizeIndex->setValue (v);
+        applySettings();
+    }
+
+    void setOverlapFactorIndex (float v) noexcept
+    {
+        overlapFactorIndex->setValue (v);
+        applySettings();
+    }
+
+    int getCurrentFFTSize() const noexcept { return getFFTSize(); }
+
+private:
+    static constexpr const char* stateType = "SpectralPassthroughState";
+    static constexpr int kFftSizeOptions[7] = { 128, 256, 512, 1024, 2048, 4096, 8192 };
+    static constexpr int kOverlapOptions[3] = { 2, 4, 8 };
+
+    void applySettings()
+    {
+        const int fftSizeIdx = yup::jlimit (0, 6, yup::roundToInt (getFFTSizeIndex()));
+        const int overlapIdx = yup::jlimit (0, 2, yup::roundToInt (getOverlapFactorIndex()));
+
+        setFFTSize (kFftSizeOptions[fftSizeIdx]);
+        setOverlapFactor (kOverlapOptions[overlapIdx]);
+    }
+
+    yup::AudioParameter::Ptr fftSizeIndex;
+    yup::AudioParameter::Ptr overlapFactorIndex;
+};
+
+//==============================================================================
+class SpectralPassthroughNodeView final : public yup::AudioGraphNodeView
+{
+public:
+    SpectralPassthroughNodeView (yup::AudioGraphNodeID nodeID, SpectralPassthroughProcessor& processorIn)
+        : AudioGraphNodeView (nodeID)
+        , processor (processorIn)
+        , fftSizeSlider (yup::Slider::LinearBarHorizontal)
+        , overlapSlider (yup::Slider::LinearBarHorizontal)
+    {
+        NodeViewHelpers::configureParameterSlider (fftSizeSlider, getPortKindColor (PortKind::parameter));
+        fftSizeSlider.setRange (0.0, 6.0, 1.0);
+        fftSizeSlider.setValue (processor.getFFTSizeIndex(), yup::dontSendNotification);
+        fftSizeSlider.onValueChanged = [this] (double value)
+        {
+            processor.setFFTSizeIndex (static_cast<float> (value));
+            repaint();
+        };
+        addAndMakeVisible (fftSizeSlider);
+
+        NodeViewHelpers::configureParameterSlider (overlapSlider, getPortKindColor (PortKind::parameter));
+        overlapSlider.setRange (0.0, 2.0, 1.0);
+        overlapSlider.setValue (processor.getOverlapFactorIndex(), yup::dontSendNotification);
+        overlapSlider.onValueChanged = [this] (double value)
+        {
+            processor.setOverlapFactorIndex (static_cast<float> (value));
+            repaint();
+        };
+        addAndMakeVisible (overlapSlider);
+    }
+
+    yup::String getNodeTitle() const override { return "SPECTRAL"; }
+
+    int getNumInputPorts() const override { return 1; }
+
+    int getNumOutputPorts() const override { return 1; }
+
+    int getPreferredWidth() const override { return 240; }
+
+    yup::Color getNodeColor() const override { return yup::Color (0xff8b5cf6); }
+
+    yup::String getNodeSubtitle() const override
+    {
+        return yup::String (processor.getCurrentFFTSize()) + " / " + yup::String (processor.getFFTSize() / processor.getOverlapFactor()) + " hop";
+    }
+
+    PortInfo getInputPortInfo (int) const override { return { "audio", getPortKindColor (PortKind::audio), PortKind::audio }; }
+
+    PortInfo getOutputPortInfo (int) const override { return { "audio", getPortKindColor (PortKind::audio), PortKind::audio }; }
+
+    int getNumParameterRows() const override { return 2; }
+
+    ParameterInfo getParameterInfo (int row) const override
+    {
+        if (row == 0)
+            return { "FFT", yup::String (processor.getCurrentFFTSize()), getPortKindColor (PortKind::parameter), -1.0f, PortKind::parameter };
+
+        return { "Overlap", yup::String (1.0f / static_cast<float> (processor.getOverlapFactor()), 2), getPortKindColor (PortKind::parameter), -1.0f, PortKind::parameter };
+    }
+
+    void resized() override
+    {
+        fftSizeSlider.setBounds (NodeViewHelpers::getInlineSliderBounds (*this, getPreferredWidth(), 0));
+        overlapSlider.setBounds (NodeViewHelpers::getInlineSliderBounds (*this, getPreferredWidth(), 1));
+    }
+
+private:
+    SpectralPassthroughProcessor& processor;
+    yup::Slider fftSizeSlider;
+    yup::Slider overlapSlider;
+};

--- a/examples/audiograph/source/nodes/StateVariableFilterNode.h
+++ b/examples/audiograph/source/nodes/StateVariableFilterNode.h
@@ -40,17 +40,15 @@ public:
         addParameter (resonance);
     }
 
-    void prepareToPlay (float newSampleRate, int blockSize) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
-        sampleRate = newSampleRate;
-
         for (auto& f : filters)
-            f.prepare (newSampleRate, blockSize);
+            f.prepare (spec.sampleRate, spec.maxBlockSize);
 
-        smoothedCutoff.reset (newSampleRate, 0.02);
+        smoothedCutoff.reset (spec.sampleRate, 0.02);
         smoothedCutoff.setCurrentAndTargetValue (static_cast<float> (getCutoff()));
 
-        smoothedResonance.reset (newSampleRate, 0.02);
+        smoothedResonance.reset (spec.sampleRate, 0.02);
         smoothedResonance.setCurrentAndTargetValue (static_cast<float> (getResonance()));
     }
 
@@ -75,7 +73,7 @@ public:
             for (int channel = 0; channel < numChannels; ++channel)
             {
                 const auto idx = static_cast<size_t> (yup::jmin (channel, 1));
-                filters[idx].setParameters (filterMode, freq, q, sampleRate);
+                filters[idx].setParameters (filterMode, freq, q, getSampleRate());
                 audioBuffer.setSample (channel, sample, filters[idx].processSample (audioBuffer.getSample (channel, sample)));
             }
         }
@@ -145,7 +143,6 @@ private:
         }
     }
 
-    float sampleRate = 44100.0f;
     yup::AudioParameter::Ptr mode;
     yup::AudioParameter::Ptr cutoff;
     yup::AudioParameter::Ptr resonance;

--- a/examples/audiograph/source/nodes/SubgraphNode.h
+++ b/examples/audiograph/source/nodes/SubgraphNode.h
@@ -134,9 +134,9 @@ public:
         model->setNodeFactory (std::move (factory));
     }
 
-    void prepareToPlay (float sampleRate, int maxBlockSize) override
+    void prepareToPlay (const yup::AudioSpec& spec) override
     {
-        graph->prepareToPlay (sampleRate, maxBlockSize);
+        graph->prepareToPlay (spec);
     }
 
     void releaseResources() override

--- a/examples/plugin/source/ExamplePlugin.cpp
+++ b/examples/plugin/source/ExamplePlugin.cpp
@@ -108,11 +108,11 @@ ExamplePlugin::~ExamplePlugin()
 
 //==============================================================================
 
-void ExamplePlugin::prepareToPlay (float sampleRate, int maxBlockSize)
+void ExamplePlugin::prepareToPlay (const yup::AudioSpec& spec)
 {
-    this->sampleRate = sampleRate;
+    this->sampleRate = spec.sampleRate;
 
-    gainHandle = yup::AudioParameterHandle (*gainParameter, sampleRate);
+    gainHandle = yup::AudioParameterHandle (*gainParameter, spec.sampleRate);
 }
 
 void ExamplePlugin::releaseResources()

--- a/examples/plugin/source/ExamplePlugin.h
+++ b/examples/plugin/source/ExamplePlugin.h
@@ -112,7 +112,7 @@ public:
     ExamplePlugin();
     ~ExamplePlugin() override;
 
-    void prepareToPlay (float sampleRate, int maxBlockSize) override;
+    void prepareToPlay (const yup::AudioSpec& spec) override;
     void releaseResources() override;
     void processBlock (yup::AudioProcessContext<float>& context) override;
     void flush() override;

--- a/modules/yup_audio_basics/buffers/yup_AudioSpectralBuffer.h
+++ b/modules/yup_audio_basics/buffers/yup_AudioSpectralBuffer.h
@@ -1,0 +1,537 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+/**
+    A multi-channel buffer for spectral (frequency-domain) data.
+
+    Each channel stores `numBins` complex-valued spectral bins as interleaved
+    `[real, imag, real, imag, ...]` pairs, backed by an AudioBuffer internally
+    (2 * numBins samples per channel).
+
+    This buffer is designed for spectral processors such as FFT-based effects,
+    phase vocoders, and frequency-domain filters. Raw `Type*` access via
+    `getWritePointer` / `getReadPointer` enables vectorized operations with
+    ComplexVectorOperations or FloatVectorOperations, while `getBinRef` provides
+    safe per-bin real/imaginary reference access.
+
+    @tags{Audio, Spectral, Realtime}
+*/
+template <typename Type>
+class SpectralBuffer
+{
+public:
+    //==============================================================================
+    /**
+        A lightweight, realtime-safe reference to a single spectral bin's
+        real and imaginary components.
+
+        BinRef holds a pointer into the buffer's interleaved data and provides
+        mutable/const reference access to the real and imaginary parts. This
+        avoids copying and is safe to use on the audio thread.
+
+        @tags{Audio, Spectral, Realtime}
+    */
+    class BinRef
+    {
+    public:
+        /** Returns a mutable reference to the real component of this bin.
+            This is realtime-safe as it only dereferences an existing pointer.
+        */
+        Type& real() noexcept { return *data; }
+
+        /** Returns a const reference to the real component of this bin.
+            This is realtime-safe as it only dereferences an existing pointer.
+        */
+        const Type& real() const noexcept { return *data; }
+
+        /** Returns a mutable reference to the imaginary component of this bin.
+            This is realtime-safe as it only dereferences an existing pointer.
+        */
+        Type& imag() noexcept { return *(data + 1); }
+
+        /** Returns a const reference to the imaginary component of this bin.
+            This is realtime-safe as it only dereferences an existing pointer.
+        */
+        const Type& imag() const noexcept { return *(data + 1); }
+
+        /** Sets both real and imaginary components of this bin in a single call.
+            This is realtime-safe.
+        */
+        void set (Type newReal, Type newImag) noexcept
+        {
+            *data = newReal;
+            *(data + 1) = newImag;
+        }
+
+        /** Computes the magnitude of this bin on-the-fly.
+            This involves a `std::sqrt` call, which should be used with caution
+            on the audio thread for large numbers of bins.
+        */
+        Type magnitude() const noexcept { return std::sqrt (real() * real() + imag() * imag()); }
+
+        /** Computes the phase (in radians) of this bin on-the-fly.
+            This involves an `std::atan2` call, which should be used with caution
+            on the audio thread for large numbers of bins.
+        */
+        Type phase() const noexcept { return std::atan2 (imag(), real()); }
+
+        /** Implicit conversion to std::complex for convenience.
+            This is realtime-safe (does not allocate).
+        */
+        operator std::complex<Type>() const noexcept { return { real(), imag() }; }
+
+    private:
+        template <class T>
+        friend class SpectralBuffer;
+
+        explicit BinRef (Type* d) noexcept
+            : data (d)
+        {
+        }
+
+        Type* data;
+    };
+
+    //==============================================================================
+    /** This allows templated code that takes a SpectralBuffer to access its sample type. */
+    using SampleType = Type;
+
+    //==============================================================================
+    /**
+        Creates an empty buffer with 0 channels and 0 bins.
+
+        This constructor is noexcept and does not allocate, making it realtime-safe.
+    */
+    SpectralBuffer() noexcept = default;
+
+    //==============================================================================
+    /**
+        Creates a buffer with a specified number of channels and spectral bins.
+
+        The contents of the buffer will initially be undefined - use clear() to
+        zero all data.
+
+        @warning This constructor may allocate memory internally, so it should
+                 not be called on the audio thread.
+
+        @param numChannels   The number of channels to allocate.
+        @param numBins       The number of spectral bins per channel.
+
+        @see setSize, clear
+    */
+    SpectralBuffer (int numChannels, int numBins)
+        : numChannels (numChannels)
+        , numBins (numBins)
+    {
+        data.setSize (numChannels, numBins * 2, false, false, false);
+    }
+
+    //==============================================================================
+    /**
+        Changes the buffer's size or number of channels.
+
+        @warning This method may allocate memory internally. When called with
+                 `keepExistingContent = true` and the new size is larger than the
+                 current allocation, or when `avoidReallocating = false`, a new
+                 allocation will occur. For realtime safety, call this method on
+                 the main thread or during non-realtime setup, and ensure the
+                 allocation is performed before audio processing begins.
+
+        @param newNumChannels      The new number of channels.
+        @param newNumBins          The new number of spectral bins per channel.
+        @param keepExistingContent If true, preserves as much of the existing data
+                                   as possible in the new buffer.
+        @param clearExtraSpace     If true, any newly allocated space beyond the
+                                   existing content will be zeroed.
+        @param avoidReallocating   If true, the buffer will not shrink its internal
+                                   allocation when the size is reduced (but will
+                                   still expand if needed).
+
+        @see AudioBuffer::setSize
+    */
+    void setSize (int newNumChannels,
+                  int newNumBins,
+                  bool keepExistingContent = false,
+                  bool clearExtraSpace = false,
+                  bool avoidReallocating = false)
+    {
+        jassert (newNumChannels >= 0);
+        jassert (newNumBins >= 0);
+
+        if (newNumChannels == numChannels && newNumBins == numBins)
+            return;
+
+        data.setSize (newNumChannels, newNumBins * 2, keepExistingContent, clearExtraSpace, avoidReallocating);
+
+        numChannels = newNumChannels;
+        numBins = newNumBins;
+    }
+
+    //==============================================================================
+    /**
+        Clears all spectral bins in all channels to zero.
+
+        This method is realtime-safe and uses vectorized operations internally.
+        If the buffer is already cleared (hasBeenCleared() returns true), this
+        is a no-op.
+
+        @see hasBeenCleared, setNotClear
+    */
+    void clear() noexcept
+    {
+        data.clear();
+    }
+
+    //==============================================================================
+    /** Returns the number of channels in this buffer.
+        This is realtime-safe.
+    */
+    int getNumChannels() const noexcept { return numChannels; }
+
+    //==============================================================================
+    /** Returns the number of spectral bins per channel.
+        This is realtime-safe.
+    */
+    int getNumBins() const noexcept { return numBins; }
+
+    //==============================================================================
+    /**
+        Returns a writeable pointer to the interleaved spectral data for a given channel.
+
+        The returned pointer points to an array of `2 * numBins` values stored as
+        `[real0, imag0, real1, imag1, ...]`. This is suitable for use with
+        FloatVectorOperations and ComplexVectorOperations.
+
+        For speed, this does not check whether the channel number is in range -
+        use an assertion build to catch out-of-bounds access.
+
+        This is realtime-safe (pointer arithmetic only).
+
+        @see getReadPointer, getBinRef, ComplexVectorOperations
+    */
+    Type* getWritePointer (int channel) noexcept
+    {
+        jassert (isPositiveAndBelow (channel, numChannels));
+
+        return data.getWritePointer (channel);
+    }
+
+    /**
+        Returns a writeable pointer to a specific spectral bin.
+    
+        This is a convenience method that calculates the correct offset for the
+        specified bin index and returns a pointer to the real component of that
+        bin. The imaginary component can be accessed at the next index.
+
+        For speed, this does not check whether the channel or bin number is in
+        range - use an assertion build to catch out-of-bounds access.
+
+        This is realtime-safe (pointer arithmetic only).
+
+        @param channel   The channel index (0-based).
+        @param bin       The bin index within the channel (0-based).
+
+        @see getReadPointer, getBinRef
+    */
+    Type* getWritePointer (int channel, int bin) noexcept
+    {
+        jassert (isPositiveAndBelow (channel, numChannels));
+        jassert (isPositiveAndBelow (bin, numBins));
+
+        return data.getWritePointer (channel) + static_cast<size_t> (bin) * 2;
+    }
+
+    //==============================================================================
+    /**
+        Returns a read-only pointer to the interleaved spectral data for a given channel.
+
+        The returned pointer points to an array of `2 * numBins` values stored as
+        `[real0, imag0, real1, imag1, ...]`. This is suitable for use with
+        FloatVectorOperations and ComplexVectorOperations.
+
+        For speed, this does not check whether the channel number is in range -
+        use an assertion build to catch out-of-bounds access.
+
+        This is realtime-safe (pointer arithmetic only).
+
+        @see getWritePointer, getBinRef, ComplexVectorOperations
+    */
+    const Type* getReadPointer (int channel) const noexcept
+    {
+        jassert (isPositiveAndBelow (channel, numChannels));
+
+        return data.getReadPointer (channel);
+    }
+
+    /**
+        Returns a read-only pointer to a specific spectral bin.
+
+        This is a convenience method that calculates the correct offset for the
+        specified bin index and returns a pointer to the real component of that
+        bin. The imaginary component can be accessed at the next index.
+
+        For speed, this does not check whether the channel or bin number is in
+        range - use an assertion build to catch out-of-bounds access.
+
+        This is realtime-safe (pointer arithmetic only).
+
+        @param channel   The channel index (0-based).
+        @param bin       The bin index within the channel (0-based).
+
+        @see getWritePointer, getBinRef
+    */
+    const Type* getReadPointer (int channel, int bin) const noexcept
+    {
+        jassert (isPositiveAndBelow (channel, numChannels));
+        jassert (isPositiveAndBelow (bin, numBins));
+
+        return data.getReadPointer (channel) + static_cast<size_t> (bin) * 2;
+    }
+
+    //==============================================================================
+    /**
+        Returns a realtime-safe reference to a specific spectral bin.
+
+        The returned BinRef provides mutable access to the real and imaginary
+        components of the bin at the specified channel and index. This is
+        lightweight (pointer-based) and safe for audio thread use.
+
+        For speed, this does not check whether the channel or bin number is in
+        range - use an assertion build to catch out-of-bounds access.
+
+        @param channel   The channel index (0-based).
+        @param bin       The bin index within the channel (0-based).
+
+        @see getWritePointer, getReadPointer
+    */
+    BinRef getBinRef (int channel, int bin) noexcept
+    {
+        jassert (isPositiveAndBelow (channel, numChannels));
+        jassert (isPositiveAndBelow (bin, numBins));
+
+        return BinRef (data.getWritePointer (channel) + static_cast<size_t> (bin) * 2);
+    }
+
+    //==============================================================================
+    /**
+        Copies a range of spectral bins from one channel of the source buffer
+        to a channel of this buffer.
+
+        This is realtime-safe and uses vectorized copy operations internally.
+        This buffer and the source buffer must not overlap for the given channels
+        and ranges.
+
+        @param destChannel        The destination channel in this buffer.
+        @param destStartBin       The first bin to write to in the destination.
+        @param source             The source buffer to copy from.
+        @param sourceChannel      The source channel to read from.
+        @param sourceStartBin     The first bin to read from in the source.
+        @param numBinsToCopy      The number of spectral bins to copy.
+
+        @see copyFrom (simple overload)
+    */
+    void copyFrom (int destChannel,
+                   int destStartBin,
+                   const SpectralBuffer<Type>& source,
+                   int sourceChannel,
+                   int sourceStartBin,
+                   int numBinsToCopy) noexcept
+    {
+        jassert (&source != this
+                 || sourceChannel != destChannel
+                 || sourceStartBin + numBinsToCopy <= destStartBin
+                 || destStartBin + numBinsToCopy <= sourceStartBin);
+        jassert (isPositiveAndBelow (destChannel, numChannels));
+        jassert (destStartBin >= 0 && destStartBin + numBinsToCopy <= numBins);
+        jassert (isPositiveAndBelow (sourceChannel, source.numChannels));
+        jassert (sourceStartBin >= 0 && sourceStartBin + numBinsToCopy <= source.numBins);
+
+        if (numBinsToCopy <= 0)
+            return;
+
+        const auto numFloats = numBinsToCopy * 2;
+        const auto destSample = destStartBin * 2;
+        const auto sourceSample = sourceStartBin * 2;
+
+        data.copyFrom (destChannel, destSample, source.data, sourceChannel, sourceSample, numFloats);
+    }
+
+    /**
+        Copies all spectral bins from one channel of the source buffer to a
+        channel of this buffer.
+
+        The number of bins in the source buffer must match the number of bins in
+        this buffer. This is realtime-safe and uses vectorized copy internally.
+
+        @param destChannel     The destination channel in this buffer.
+        @param source          The source buffer to copy from.
+        @param sourceChannel   The source channel to read from.
+
+        @see copyFrom (ranged overload)
+    */
+    void copyFrom (int destChannel,
+                   const SpectralBuffer<Type>& source,
+                   int sourceChannel) noexcept
+    {
+        jassert (source.numBins == numBins);
+
+        copyFrom (destChannel, 0, source, sourceChannel, 0, numBins);
+    }
+
+    //==============================================================================
+    /**
+        Resizes this buffer to match the given one and copies all its content.
+
+        The source buffer can hold a different floating point type, enabling
+        conversion between float and double spectral buffers.
+
+        @warning This method may allocate memory internally. See setSize() for
+                 realtime safety considerations.
+
+        @param other              The source buffer to copy from.
+        @param avoidReallocating  If true, avoids shrinking the internal allocation.
+
+        @see setSize
+    */
+    template <typename OtherType>
+    void makeCopyOf (const SpectralBuffer<OtherType>& other, bool avoidReallocating = false)
+    {
+        setSize (other.getNumChannels(), other.getNumBins(), false, false, avoidReallocating);
+
+        if (other.hasBeenCleared())
+        {
+            clear();
+        }
+        else
+        {
+            for (int chan = 0; chan < numChannels; ++chan)
+            {
+                auto* dest = getWritePointer (chan);
+                auto* src = other.getReadPointer (chan);
+
+                for (int i = 0; i < numBins * 2; ++i)
+                    dest[i] = static_cast<Type> (src[i]);
+            }
+        }
+    }
+
+    //==============================================================================
+    /**
+        Fills all bins in a single channel with a constant real/imaginary value pair.
+
+        This is realtime-safe.
+
+        @param channel      The channel to fill.
+        @param realValue    The real component value to fill.
+        @param imagValue    The imaginary component value to fill.
+    */
+    void fill (int channel, Type realValue, Type imagValue) noexcept
+    {
+        jassert (isPositiveAndBelow (channel, numChannels));
+
+        auto* ptr = getWritePointer (channel);
+
+        for (int i = 0; i < numBins; ++i)
+        {
+            *ptr++ = realValue;
+            *ptr++ = imagValue;
+        }
+
+        setNotClear();
+    }
+
+    /**
+        Fills all bins in all channels with a constant real/imaginary value pair.
+
+        This is realtime-safe.
+
+        @param realValue    The real component value to fill.
+        @param imagValue    The imaginary component value to fill.
+    */
+    void fill (Type realValue, Type imagValue) noexcept
+    {
+        for (int i = 0; i < numChannels; ++i)
+            fill (i, realValue, imagValue);
+
+        if (realValue != static_cast<Type> (0) || imagValue != static_cast<Type> (0))
+            setNotClear();
+    }
+
+    //==============================================================================
+    /** Returns true if the buffer has been entirely cleared via clear().
+        This is realtime-safe.
+    */
+    bool hasBeenCleared() const noexcept { return data.hasBeenCleared(); }
+
+    /** Forces the internal cleared flag to false.
+        This is realtime-safe.
+    */
+    void setNotClear() noexcept { data.setNotClear(); }
+
+private:
+    //==============================================================================
+    AudioBuffer<Type> data;
+    int numChannels = 0, numBins = 0;
+
+    YUP_LEAK_DETECTOR (SpectralBuffer)
+};
+
+//==============================================================================
+template <typename Type>
+bool operator== (const SpectralBuffer<Type>& a, const SpectralBuffer<Type>& b)
+{
+    if (a.getNumChannels() != b.getNumChannels())
+        return false;
+
+    if (a.getNumBins() != b.getNumBins())
+        return false;
+
+    for (int c = 0; c < a.getNumChannels(); ++c)
+    {
+        const auto* pa = a.getReadPointer (c);
+        const auto* pb = b.getReadPointer (c);
+
+        if (! std::equal (pa, pa + a.getNumBins() * 2, pb))
+            return false;
+    }
+
+    return true;
+}
+
+template <typename Type>
+bool operator!= (const SpectralBuffer<Type>& a, const SpectralBuffer<Type>& b)
+{
+    return ! (a == b);
+}
+
+//==============================================================================
+/**
+    A multi-channel buffer of 32-bit floating point spectral samples.
+
+    @see SpectralBuffer
+*/
+using AudioSpectralBuffer = SpectralBuffer<float>;
+
+} // namespace yup

--- a/modules/yup_audio_basics/yup_audio_basics.h
+++ b/modules/yup_audio_basics/yup_audio_basics.h
@@ -74,6 +74,7 @@
 //==============================================================================
 #include "buffers/yup_AudioDataConverters.h"
 #include "buffers/yup_AudioSampleBuffer.h"
+#include "buffers/yup_AudioSpectralBuffer.h"
 #include "buffers/yup_AudioChannelSet.h"
 #include "buffers/yup_AudioProcessLoadMeasurer.h"
 #include "utilities/yup_Decibels.h"

--- a/modules/yup_audio_devices/audio_io/yup_AudioDeviceManager.cpp
+++ b/modules/yup_audio_devices/audio_io/yup_AudioDeviceManager.cpp
@@ -148,6 +148,7 @@ AudioDeviceManager::AudioDeviceManager()
 
 AudioDeviceManager::~AudioDeviceManager()
 {
+    enabledMidiInputs.clear();
     currentAudioDevice.reset();
     defaultMidiOutput.reset();
 }

--- a/modules/yup_audio_graph/graph/yup_AudioGraphProcessor.cpp
+++ b/modules/yup_audio_graph/graph/yup_AudioGraphProcessor.cpp
@@ -392,10 +392,10 @@ public:
         return Result::ok();
     }
 
-    void prepareToPlay (float newSampleRate, int newMaxBlockSize)
+    void prepareToPlay (const AudioSpec& spec)
     {
-        sampleRate = newSampleRate;
-        maxBlockSize = jmax (1, newMaxBlockSize);
+        sampleRate = spec.sampleRate;
+        maxBlockSize = jmax (1, spec.maxBlockSize);
 
         const auto result = commitChanges();
         jassert (result.wasOk());
@@ -424,7 +424,7 @@ public:
         lastCompiledMaxBlockSize = 0;
     }
 
-    void audioProcessorChanged (AudioProcessor*, const AudioProcessor::ChangeDetails& details) override
+    void audioProcessorChanged (AudioProcessorBase*, const AudioProcessor::ChangeDetails& details) override
     {
         if (details.latencyChanged)
         {
@@ -1387,9 +1387,9 @@ Result AudioGraphProcessor::restoreFromXml (const XmlElement& xml)
     return pimpl->restoreFromXml (xml);
 }
 
-void AudioGraphProcessor::prepareToPlay (float sampleRate, int maxBlockSize)
+void AudioGraphProcessor::prepareToPlay (const AudioSpec& spec)
 {
-    pimpl->prepareToPlay (sampleRate, maxBlockSize);
+    pimpl->prepareToPlay (spec);
 }
 
 void AudioGraphProcessor::releaseResources()

--- a/modules/yup_audio_graph/graph/yup_AudioGraphProcessor.h
+++ b/modules/yup_audio_graph/graph/yup_AudioGraphProcessor.h
@@ -34,6 +34,8 @@ namespace yup
     properties are saved by the model without invalidating the compiled plan.
     processBlock() only swaps pending plans at block boundaries and keeps retired
     plans alive until a later control-thread commit or destruction.
+
+    @tags{Audio, Graph, Realtime}
 */
 class YUP_API AudioGraphProcessor final : public AudioProcessor
 {
@@ -43,7 +45,20 @@ public:
 
     //==============================================================================
 
-    /** Constructs an audio graph that compiles and processes an external graph model. */
+    /** Constructs an audio graph that compiles and processes an external graph model.
+    
+        The model should be shared with the UI and other control-thread components
+        that edit the graph topology and node properties. The processor will call
+        commitChanges() to validate and publish changes made to the model, but it
+        does not automatically commit on every edit - this allows batching of edits
+        for more efficient updates.
+
+        @param model         The shared graph model to use for topology and state.
+        @param busLayout     The initial bus layout for the graph. This can be changed
+                            later by editing the model and committing changes.
+
+        @see AudioGraphModel, commitChanges
+    */
     explicit AudioGraphProcessor (std::shared_ptr<AudioGraphModel> model,
                                   AudioBusLayout busLayout = createDefaultBusLayout());
 
@@ -52,43 +67,137 @@ public:
 
     //==============================================================================
 
-    /** Returns the editable graph model consumed by this processor. */
+    /** Returns the editable graph model consumed by this processor.
+    
+        This model is shared with the UI and other control-thread components that edit
+        the graph topology and node properties. Changes made to the model will not
+        take effect until commitChanges() is called to validate and publish them.
+
+        @return The shared graph model used by this processor.
+    */
     std::shared_ptr<AudioGraphModel> getModel() const noexcept;
 
     //==============================================================================
 
-    /** Validates, compiles, and publishes the current graph topology when needed. */
+    /** Validates, compiles, and publishes the current graph topology when needed.
+    
+        This should be called after making edits to the graph model to validate the
+        topology, prepare any new nodes for processing, and publish an immutable
+        processing plan that will be used by processBlock(). This allows batching
+        of multiple edits before committing, which can improve efficiency when making
+        several changes at once.
+
+        During commitChanges(), the graph will check for cycles, verify that all
+        nodes can be prepared with the current playback configuration, and ensure
+        that all connections are valid. If any issues are found, the commit will fail
+        and the graph will remain in its previous state.
+
+        For realtime safety, this method should be called on the main thread or during
+        non-realtime setup. Changes will take effect on the next call to processBlock()
+        after this method is called.
+
+        @return Result indicating success or failure of the commit operation.
+    */
     Result commitChanges();
 
-    /** Validates one connection against the current model and graph bus layout. */
+    /** Validates one connection against the current model and graph bus layout.
+    
+        This can be used by the UI to provide immediate feedback on the validity of
+        a proposed connection before committing it to the model. The connection
+        should be validated again during commitChanges() to ensure thread safety.
+
+        @param connection    The proposed connection to validate.
+
+        @see commitChanges
+    */
     Result validateConnection (const AudioGraphConnection& connection) const;
 
-    /** Returns true when topology edits have not yet been committed. */
+    /** Returns true when topology edits have not yet been committed.
+    
+        This can be used by the UI to indicate that there are pending changes that
+        have not yet been validated and published to the audio thread. Once
+        commitChanges() is called, this will return false until new edits are made.
+
+        @see commitChanges
+    */
     bool hasUncommittedChanges() const noexcept;
 
     //==============================================================================
-    /** Sets the desired worker thread count for future processing blocks. */
+    /** Sets the desired worker thread count for future processing blocks.
+    
+        This is a hint that allows the graph to utilize multiple threads for processing
+        when supported by the current graph topology and host configuration. The
+        actual number of threads used may be less than the requested count based on
+        internal heuristics.
+
+         For realtime safety, this method should be called on the main thread or
+         during non-realtime setup. Changes will take effect on the next call to
+         processBlock() after any pending topology changes have been committed.
+
+        @param numThreads   The desired number of worker threads to use (0 for no workers).
+    */
     void setNumWorkerThreads (int numThreads);
 
-    /** Returns the desired worker thread count. */
+    /** Returns the desired worker thread count.
+    
+        This returns the last value set by setNumWorkerThreads(), which is a hint for
+        the graph's internal thread usage. The actual number of threads used for
+        processing may be less than this value based on internal heuristics and the
+        current graph topology.
+
+        @return The desired number of worker threads to use (0 for no workers).
+    */
     int getNumWorkerThreads() const noexcept;
 
-    /** Supplies the audio workgroup that worker threads should join when supported. */
+    /** Supplies the audio workgroup that worker threads should join when supported.
+    
+        This is a hint that allows the graph to utilize host-provided workgroups for
+        processing when supported by the current graph topology and host configuration.
+        For realtime safety, this method should be called on the main thread or during
+        non-realtime setup. Changes will take effect on the next call to processBlock()
+        after any pending topology changes have been committed.
+
+        @param workgroup    The audio workgroup to join, or an empty object to not use workgroups.
+    */
     void setAudioWorkgroup (AudioWorkgroup workgroup);
 
-    /** Returns diagnostics for the last successfully compiled graph. */
+    /** Returns diagnostics for the last successfully compiled graph.
+    
+        This can be used to retrieve information about the compiled graph, such as
+        node counts, latency, and resource usage. The diagnostics are updated on
+        each successful call to commitChanges().
+
+        @return An object containing allocation and performance statistics for the graph.
+    */
     AudioGraphAllocationStats getAllocationStats() const noexcept;
 
     //==============================================================================
-    /** Creates an XML representation of the current graph, including node state. */
+    /** Creates an XML representation of the current graph, including node state.
+
+        This is not realtime-safe and should be called on the main thread or during
+        non-realtime setup. The XML can be saved and later passed to restoreFromXml()
+        to restore the graph's state.
+
+        @return An XML element representing the current graph state.
+    */
     std::unique_ptr<XmlElement> createXml() const;
 
-    /** Restores the graph from XML previously created by createXml(). */
+    /** Restores the graph from XML previously created by createXml().
+    
+        This is not realtime-safe and should be called on the main thread or during
+        non-realtime setup. The graph will be recompiled and all pending plans will
+        be replaced, so this should only be called when audio processing is stopped
+        or when the graph is not actively processing.
+
+        @param xml   The XML element to restore from.
+
+        @return Result indicating success or failure of the restore operation.
+    */
     Result restoreFromXml (const XmlElement& xml);
 
     //==============================================================================
     // AudioProcessor
-    void prepareToPlay (float sampleRate, int maxBlockSize) override;
+    void prepareToPlay (const AudioSpec& spec) override;
     void releaseResources() override;
     void processBlock (AudioProcessContext<float>& context) override;
     void flush() override;
@@ -106,7 +215,6 @@ public:
     void setPresetName (int, StringRef) override {}
 
     Result loadStateFromMemory (const MemoryBlock& memoryBlock) override;
-
     Result saveStateIntoMemory (MemoryBlock& memoryBlock) override;
 
     bool hasEditor() const override { return false; }

--- a/modules/yup_audio_plugin_client/clap/yup_audio_plugin_client_CLAP.cpp
+++ b/modules/yup_audio_plugin_client/clap/yup_audio_plugin_client_CLAP.cpp
@@ -526,7 +526,7 @@ private:
     void parameterGestureBegin (const AudioParameter::Ptr& parameter, int indexInContainer) override;
     void parameterGestureEnd (const AudioParameter::Ptr& parameter, int indexInContainer) override;
 
-    void audioProcessorChanged (AudioProcessor* processor, const AudioProcessor::ChangeDetails& details) override;
+    void audioProcessorChanged (AudioProcessorBase* processor, const AudioProcessor::ChangeDetails& details) override;
 
     void enqueueParameterEvent (uint16 eventType, clap_id parameterId, double value = 0.0) noexcept;
     void drainParameterEvents (const clap_output_events_t* out) noexcept;
@@ -1689,7 +1689,7 @@ void AudioPluginProcessorCLAP::parameterGestureEnd (const AudioParameter::Ptr& p
     requestParameterFlush();
 }
 
-void AudioPluginProcessorCLAP::audioProcessorChanged (AudioProcessor* processor, const AudioProcessor::ChangeDetails& details)
+void AudioPluginProcessorCLAP::audioProcessorChanged (AudioProcessorBase* processor, const AudioProcessor::ChangeDetails& details)
 {
     ignoreUnused (processor);
 

--- a/modules/yup_audio_plugin_client/standalone/yup_audio_plugin_client_Standalone.cpp
+++ b/modules/yup_audio_plugin_client/standalone/yup_audio_plugin_client_Standalone.cpp
@@ -144,7 +144,7 @@ public:
 
     void audioDeviceAboutToStart (AudioIODevice* device) override
     {
-        processor->prepareToPlay (device->getCurrentSampleRate(), device->getCurrentBufferSizeSamples());
+        processor->prepareToPlay (AudioSpec (device->getCurrentSampleRate(), device->getCurrentBufferSizeSamples()));
 
         audioBuffer.setSize (
             jmax (

--- a/modules/yup_audio_plugin_client/vst3/yup_audio_plugin_client_VST3.cpp
+++ b/modules/yup_audio_plugin_client/vst3/yup_audio_plugin_client_VST3.cpp
@@ -1086,7 +1086,7 @@ private:
         }
     }
 
-    void audioProcessorChanged (AudioProcessor* processor, const AudioProcessor::ChangeDetails& details) override
+    void audioProcessorChanged (AudioProcessorBase* processor, const AudioProcessor::ChangeDetails& details) override
     {
         ignoreUnused (processor);
 

--- a/modules/yup_audio_plugin_host/native/yup_AudioPluginInstance_AUv2.mm
+++ b/modules/yup_audio_plugin_host/native/yup_AudioPluginInstance_AUv2.mm
@@ -376,7 +376,7 @@ class AUv2Instance : public AudioPluginInstance, private AudioParameter::Listene
 
     //==============================================================================
 
-    void prepareToPlay(float sampleRate, int maxBlockSize) override
+    void prepareToPlay(const AudioSpec& spec) override
     {
         releaseResources();
 
@@ -386,15 +386,15 @@ class AUv2Instance : public AudioPluginInstance, private AudioParameter::Listene
         const auto numHostedChannels = jmax(2,
                                             pluginDescription.numInputChannels,
                                             pluginDescription.numOutputChannels);
-        prepareRenderStorage(numHostedChannels, maxBlockSize);
+        prepareRenderStorage(numHostedChannels, spec.maxBlockSize);
 
-        const Float64 sampleRateValue = static_cast<Float64>(sampleRate);
+        const Float64 sampleRateValue = static_cast<Float64>(spec.sampleRate);
         AudioUnitSetProperty(audioUnit,
                              kAudioUnitProperty_SampleRate,
                              kAudioUnitScope_Global, 0,
                              &sampleRateValue, sizeof(sampleRateValue));
 
-        UInt32 blockSize = static_cast<UInt32>(maxBlockSize);
+        UInt32 blockSize = static_cast<UInt32>(spec.maxBlockSize);
         AudioUnitSetProperty(audioUnit,
                              kAudioUnitProperty_MaximumFramesPerSlice,
                              kAudioUnitScope_Global, 0,

--- a/modules/yup_audio_plugin_host/native/yup_AudioPluginInstance_CLAP.cpp
+++ b/modules/yup_audio_plugin_host/native/yup_AudioPluginInstance_CLAP.cpp
@@ -767,14 +767,14 @@ public:
 
     //==============================================================================
 
-    void prepareToPlay (float sampleRate, int maxBlockSize) override
+    void prepareToPlay (const AudioSpec& spec) override
     {
         const int numChannels = jmax (2, pluginDescription.numInputChannels, pluginDescription.numOutputChannels);
         preparedInPtrs.resize (static_cast<std::size_t> (numChannels));
         preparedOutPtrs.resize (static_cast<std::size_t> (numChannels));
 
         updateRenderMode();
-        clapPlugin->activate (clapPlugin, sampleRate, 1, static_cast<uint32_t> (jmax (1, maxBlockSize)));
+        clapPlugin->activate (clapPlugin, spec.sampleRate, 1, static_cast<uint32_t> (jmax (1, spec.maxBlockSize)));
         updateRenderMode();
 
         clapPlugin->start_processing (clapPlugin);

--- a/modules/yup_audio_plugin_host/native/yup_AudioPluginInstance_VST3.cpp
+++ b/modules/yup_audio_plugin_host/native/yup_AudioPluginInstance_VST3.cpp
@@ -1015,7 +1015,7 @@ public:
 
     //==============================================================================
 
-    void prepareToPlay (float sampleRate, int maxBlockSize) override
+    void prepareToPlay (const AudioSpec& spec) override
     {
         Vst::ProcessSetup setup;
         setup.processMode = isNonRealtime() ? Vst::kOffline : Vst::kRealtime;
@@ -1024,8 +1024,8 @@ public:
                                     : ProcessingPrecision::singlePrecision);
 
         setup.symbolicSampleSize = isUsingDoublePrecision() ? Vst::kSample64 : Vst::kSample32;
-        setup.maxSamplesPerBlock = maxBlockSize;
-        setup.sampleRate = sampleRate;
+        setup.maxSamplesPerBlock = spec.maxBlockSize;
+        setup.sampleRate = spec.sampleRate;
 
         const int numInputs = vst3Component->getBusCount (Vst::kAudio, Vst::kInput);
         const int numOutputs = vst3Component->getBusCount (Vst::kAudio, Vst::kOutput);
@@ -1033,7 +1033,7 @@ public:
         if (isUsingDoublePrecision())
         {
             const int numChannels = jmax (1, numInputs, numOutputs);
-            doublePrecisionBuffer.setSize (numChannels, maxBlockSize, false, true, false);
+            doublePrecisionBuffer.setSize (numChannels, spec.maxBlockSize, false, true, false);
         }
 
         vst3Processor->setupProcessing (setup);

--- a/modules/yup_audio_processors/processors/yup_AudioBusLayout.h
+++ b/modules/yup_audio_processors/processors/yup_AudioBusLayout.h
@@ -64,6 +64,24 @@ public:
     /** Returns all output buses. */
     Span<const AudioBus> getOutputBuses() const noexcept { return outputBuses; }
 
+    /** Returns the total number of audio input channels across all input buses. */
+    int getNumAudioInputChannels() const { return getNumAudioChannels (inputBuses); }
+
+    /** Returns the total number of audio output channels across all output buses. */
+    int getNumAudioOutputChannels() const { return getNumAudioChannels (outputBuses); }
+
+    /** Returns the total number of audio channels across the given buses. */
+    int getNumAudioChannels (Span<const AudioBus> buses) const
+    {
+        int numChannels = 0;
+
+        for (const auto& bus : buses)
+            if (bus.getType() == AudioBus::Type::Audio)
+                numChannels += bus.getNumChannels();
+
+        return numChannels;
+    }
+
 private:
     std::vector<AudioBus> inputBuses;
     std::vector<AudioBus> outputBuses;

--- a/modules/yup_audio_processors/processors/yup_AudioProcessorBase.cpp
+++ b/modules/yup_audio_processors/processors/yup_AudioProcessorBase.cpp
@@ -1,0 +1,186 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2024 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+
+AudioProcessorBase::AudioProcessorBase (StringRef name)
+    : processorName (name)
+{
+}
+
+//==============================================================================
+
+AudioProcessorBase::~AudioProcessorBase() = default;
+
+//==============================================================================
+
+void AudioProcessorBase::addParameter (AudioParameter::Ptr parameter)
+{
+    jassert (parameter != nullptr);
+    if (parameter == nullptr)
+        return;
+
+    if (parameterMap.find (parameter->getID()) != parameterMap.end())
+        return;
+
+    const auto hostParameterID = parameter->hasExplicitHostParameterID()
+                                   ? parameter->getHostParameterID()
+                                   : static_cast<uint32> (parameters.size());
+    jassert (hostParameterID != AudioParameter::invalidHostParameterID);
+    jassert (hostParameterID <= AudioParameter::maximumHostParameterID);
+
+    if (parameterHostIDMap.find (hostParameterID) != parameterHostIDMap.end())
+    {
+        jassertfalse;
+        return;
+    }
+
+    parameter->setIndexInContainer (static_cast<int> (parameters.size()));
+
+    parameterMap.emplace (parameter->getID(), parameter);
+    parameterHostIDMap.emplace (hostParameterID, parameter);
+    parameters.emplace_back (std::move (parameter));
+}
+
+AudioParameter::Ptr AudioProcessorBase::getParameterByID (StringRef parameterID) const
+{
+    const auto iterator = parameterMap.find (String (parameterID));
+    return iterator != parameterMap.end() ? iterator->second : nullptr;
+}
+
+AudioParameter::Ptr AudioProcessorBase::getParameterByHostID (uint32 hostParameterID) const
+{
+    const auto iterator = parameterHostIDMap.find (hostParameterID);
+    return iterator != parameterHostIDMap.end() ? iterator->second : nullptr;
+}
+
+int AudioProcessorBase::getParameterIndexByHostID (uint32 hostParameterID) const
+{
+    if (auto parameter = getParameterByHostID (hostParameterID))
+        return parameter->getIndexInContainer();
+
+    return -1;
+}
+
+void AudioProcessorBase::addListener (Listener* listener)
+{
+    listeners.add (listener);
+}
+
+void AudioProcessorBase::removeListener (Listener* listener)
+{
+    listeners.remove (listener);
+}
+
+void AudioProcessorBase::updateHostDisplay (ChangeDetails details)
+{
+    listeners.call (&Listener::audioProcessorChanged, this, details);
+}
+
+//==============================================================================
+
+Result AudioProcessorBase::loadStateFromDataTree (const DataTree& state)
+{
+    ignoreUnused (state);
+    return Result::fail ("Processor does not support DataTree state");
+}
+
+Result AudioProcessorBase::saveStateIntoDataTree (DataTree& state)
+{
+    ignoreUnused (state);
+    return Result::fail ("Processor does not support DataTree state");
+}
+
+Result AudioProcessorBase::loadStateFromMemory (const MemoryBlock& memoryBlock)
+{
+    if (! supportsDataTreeState())
+        return Result::fail ("Processor does not support binary state");
+
+    MemoryInputStream stream (memoryBlock, false);
+    auto xml = parseXML (stream.readEntireStreamAsString());
+
+    if (xml == nullptr)
+        return Result::fail ("Processor state is not valid XML");
+
+    auto state = DataTree::fromXml (*xml);
+    if (! state.isValid())
+        return Result::fail ("Processor state is not a valid DataTree");
+
+    return loadStateFromDataTree (state);
+}
+
+Result AudioProcessorBase::saveStateIntoMemory (MemoryBlock& memoryBlock)
+{
+    if (! supportsDataTreeState())
+        return Result::fail ("Processor does not support binary state");
+
+    DataTree state;
+    if (const auto result = saveStateIntoDataTree (state); result.failed())
+        return result;
+
+    auto xml = state.createXml();
+    if (xml == nullptr)
+        return Result::fail ("Processor DataTree state is invalid");
+
+    MemoryOutputStream stream (memoryBlock, false);
+    xml->writeTo (stream);
+    stream.flush();
+
+    return Result::ok();
+}
+
+//==============================================================================
+
+void AudioProcessorBase::suspendProcessing (bool shouldSuspend)
+{
+    auto lock = CriticalSection::ScopedLockType (processLock);
+
+    processIsSuspended.fetch_add (shouldSuspend ? 1 : -1);
+}
+
+bool AudioProcessorBase::isSuspended() const
+{
+    return processIsSuspended.load() > 0;
+}
+
+//==============================================================================
+
+void AudioProcessorBase::setLatencySamples (int newLatencySamples)
+{
+    const auto clampedLatencySamples = jmax (0, newLatencySamples);
+    const auto oldLatencySamples = latencySamples.exchange (clampedLatencySamples);
+
+    if (oldLatencySamples != clampedLatencySamples)
+        updateHostDisplay (ChangeDetails().withLatencyChanged (true));
+}
+
+//==============================================================================
+
+void AudioProcessorBase::setPlaybackConfiguration (float sampleRate, int samplesPerBlock)
+{
+    this->sampleRate = sampleRate;
+    this->samplesPerBlock = samplesPerBlock;
+}
+
+} // namespace yup

--- a/modules/yup_audio_processors/processors/yup_AudioProcessorBase.h
+++ b/modules/yup_audio_processors/processors/yup_AudioProcessorBase.h
@@ -1,0 +1,328 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2024 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+/**
+    Base class for all audio domains processors.
+
+    The AudioProcessorBase class is the base class for all audio processing domain modules
+    in the framework. It provides a common interface for processing parameters, handling
+    presets, dealing with latency and tails, suspending and resuming processing, and
+    communicating with hosts.
+
+    @see AudioProcessorEditor
+*/
+class YUP_API AudioProcessorBase
+{
+public:
+    //==============================================================================
+    /** Details about a processor-level change notification. */
+    struct ChangeDetails
+    {
+        /** Returns a copy of these details with the latency change flag set. */
+        ChangeDetails withLatencyChanged (bool shouldBeLatencyChanged) const noexcept
+        {
+            auto copy = *this;
+            copy.latencyChanged = shouldBeLatencyChanged;
+            return copy;
+        }
+
+        /** Returns a copy of these details with the tail length change flag set. */
+        ChangeDetails withTailChanged (bool shouldBeTailChanged) const noexcept
+        {
+            auto copy = *this;
+            copy.tailChanged = shouldBeTailChanged;
+            return copy;
+        }
+
+        /** Returns a copy of these details with the parameter value change flag set. */
+        ChangeDetails withParameterValuesChanged (bool shouldBeParameterValuesChanged) const noexcept
+        {
+            auto copy = *this;
+            copy.parameterValuesChanged = shouldBeParameterValuesChanged;
+            return copy;
+        }
+
+        /** Returns a copy of these details with the parameter metadata change flag set. */
+        ChangeDetails withParameterInfoChanged (bool shouldBeParameterInfoChanged) const noexcept
+        {
+            auto copy = *this;
+            copy.parameterInfoChanged = shouldBeParameterInfoChanged;
+            return copy;
+        }
+
+        /** Returns a copy of these details with the non-parameter state change flag set. */
+        ChangeDetails withNonParameterStateChanged (bool shouldBeNonParameterStateChanged) const noexcept
+        {
+            auto copy = *this;
+            copy.nonParameterStateChanged = shouldBeNonParameterStateChanged;
+            return copy;
+        }
+
+        /** True when the processor latency may have changed. */
+        bool latencyChanged = false;
+
+        /** True when the processor tail length may have changed. */
+        bool tailChanged = false;
+
+        /** True when one or more parameter values may have changed without a host automation event. */
+        bool parameterValuesChanged = false;
+
+        /** True when one or more parameter names, ranges, or display conversions may have changed. */
+        bool parameterInfoChanged = false;
+
+        /** True when non-parameter processor state may have changed. */
+        bool nonParameterStateChanged = false;
+    };
+
+    //==============================================================================
+    /** Receives processor-level change notifications. */
+    class Listener
+    {
+    public:
+        virtual ~Listener() = default;
+
+        /** Called when a processor-level property changes. */
+        virtual void audioProcessorChanged (AudioProcessorBase* processor, const ChangeDetails& details) = 0;
+    };
+
+    //==============================================================================
+    /** Constructs an AudioProcessorBase. */
+    AudioProcessorBase (StringRef name);
+
+    /** Destructs an AudioProcessorBase. */
+    virtual ~AudioProcessorBase();
+
+    //==============================================================================
+    /** Returns the name of the processor. */
+    String getName() const { return processorName; }
+
+    //==============================================================================
+    /** Returns the parameters. */
+    Span<const AudioParameter::Ptr> getParameters() const { return parameters; }
+
+    /** Returns a parameter by stable ID, or nullptr when no such parameter exists. */
+    AudioParameter::Ptr getParameterByID (StringRef parameterID) const;
+
+    /** Returns a parameter by host-facing automation ID, or nullptr when no such parameter exists. */
+    AudioParameter::Ptr getParameterByHostID (uint32 hostParameterID) const;
+
+    /** Returns a parameter index by host-facing automation ID, or -1 when no such parameter exists. */
+    int getParameterIndexByHostID (uint32 hostParameterID) const;
+
+    /** Adds a parameter. */
+    void addParameter (AudioParameter::Ptr parameter);
+
+    //==============================================================================
+    /** Adds a processor-level change listener. */
+    void addListener (Listener* listener);
+
+    /** Removes a processor-level change listener. */
+    void removeListener (Listener* listener);
+
+    /** Notifies listeners that processor-level details have changed. */
+    void updateHostDisplay (ChangeDetails details);
+
+    //==============================================================================
+    /** Returns the critical section used to protect the audio processing code. */
+    CriticalSection& getProcessLock() { return processLock; }
+
+    /** Returns true if the processor is currently suspended. */
+    bool isSuspended() const;
+
+    /** Suspends or resumes the processor. */
+    virtual void suspendProcessing (bool shouldSuspend);
+
+    /** RAII helper class to automatically suspend and resume processing.
+
+        @code
+        {
+            AudioProcessorBase::ScopedProcessSuspension suspension (*this);
+            // processing is suspended within this scope
+        }
+        // processing is resumed here
+    */
+    struct ScopedProcessSuspension
+    {
+        /** Constructs a ScopedProcessSuspension and suspends processing. */
+        explicit ScopedProcessSuspension (AudioProcessorBase& processor, bool startSuspended = true)
+            : processor (processor)
+        {
+            if (startSuspended)
+                setSuspended();
+        }
+
+        /** Destructs a ScopedProcessSuspension and resumes processing. */
+        ~ScopedProcessSuspension()
+        {
+            if (wasSuspended)
+                processor.suspendProcessing (false);
+        }
+
+        /** Manually suspends processing if it wasn't already suspended in the constructor. */
+        void setSuspended()
+        {
+            if (wasSuspended)
+                return;
+
+            processor.suspendProcessing (true);
+            wasSuspended = true;
+        }
+
+    private:
+        AudioProcessorBase& processor;
+        bool wasSuspended = false;
+    };
+
+    //==============================================================================
+    /** Returns the current sample rate. */
+    float getSampleRate() const { return sampleRate; }
+
+    /** Returns the current block size in samples. */
+    int getSamplesPerBlock() const { return samplesPerBlock; }
+
+    //==============================================================================
+    /** Returns the number of tail samples. */
+    virtual int getTailSamples() { return 0; }
+
+    /** Returns the latency in samples. */
+    virtual int getLatencySamples() { return latencySamples.load(); }
+
+    /** Sets the processor latency in samples and notifies listeners when it changes. */
+    void setLatencySamples (int newLatencySamples);
+
+    //==============================================================================
+    /** Returns true when the processor is running in offline (non-realtime) mode. */
+    bool isOfflineProcessing() const noexcept { return offlineProcessing.load(); }
+
+    /** Called by the plugin wrapper to indicate offline vs. realtime rendering. */
+    void setOfflineProcessing (bool offline) { offlineProcessing.store (offline); }
+
+    //==============================================================================
+    /** Returns the current preset index. */
+    virtual int getCurrentPreset() const noexcept = 0;
+
+    /** Sets the current preset index.
+
+        @param index The index of the preset to select.
+    */
+    virtual void setCurrentPreset (int index) noexcept = 0;
+
+    /** Returns the number of available user presets. */
+    virtual int getNumPresets() const = 0;
+
+    /** Returns the name of a preset by index.
+      
+        @param index The index of the preset.
+
+        @return The name of the preset.
+    */
+    virtual String getPresetName (int index) const = 0;
+
+    /** Sets the name of a preset by index.
+
+        @param index The index of the preset.
+        @param newName The new name for the preset.
+    */
+    virtual void setPresetName (int index, StringRef newName) = 0;
+
+    //==============================================================================
+    /** Returns true when this processor supports structured DataTree state.
+
+        Processors that return true can use the default binary state transport,
+        which serializes the DataTree state as XML into a MemoryBlock.
+    */
+    virtual bool supportsDataTreeState() const noexcept { return false; }
+
+    /** Loads a preset from a structured DataTree.
+
+        The default implementation returns a failure. Override this together with
+        saveStateIntoDataTree() and supportsDataTreeState() for processors that
+        want XML-readable state while still using MemoryBlock transport in plugin
+        wrappers.
+
+        @param state The structured state to load.
+
+        @return The result of the operation.
+    */
+    virtual Result loadStateFromDataTree (const DataTree& state);
+
+    /** Saves the current state into a structured DataTree.
+
+        The implementation should assign a valid DataTree to @p state.
+
+        @param state The structured state destination.
+
+        @return The result of the operation.
+    */
+    virtual Result saveStateIntoDataTree (DataTree& state);
+
+    /** Loads a preset from a memory block.
+
+        The default implementation is available to processors that return true
+        from supportsDataTreeState(): it parses XML from the memory block and
+        forwards the resulting DataTree to loadStateFromDataTree(). Processors
+        that need opaque binary state should override this method.
+
+        @param memoryBlock The memory block to load the state from.
+
+        @return The result of the operation.
+    */
+    virtual Result loadStateFromMemory (const MemoryBlock& memoryBlock);
+
+    /** Saves the current state as a memory block.
+
+        The default implementation is available to processors that return true
+        from supportsDataTreeState(): it calls saveStateIntoDataTree() and writes
+        the resulting XML into the memory block. Processors that need opaque
+        binary state should override this method.
+
+        @param memoryBlock The memory block to save the state to.
+
+        @return The result of the operation.
+    */
+    virtual Result saveStateIntoMemory (MemoryBlock& memoryBlock);
+
+    //==============================================================================
+    /** @internal Used by plugin wrappers. */
+    virtual void setPlaybackConfiguration (float sampleRate, int samplesPerBlock);
+
+private:
+    String processorName;
+
+    std::vector<AudioParameter::Ptr> parameters;
+    std::unordered_map<String, AudioParameter::Ptr> parameterMap;
+    std::unordered_map<uint32, AudioParameter::Ptr> parameterHostIDMap;
+    ListenerList<Listener, Array<Listener*, CriticalSection>> listeners;
+
+    float sampleRate = 44100.0f;
+    int samplesPerBlock = 1024;
+    std::atomic<int> latencySamples { 0 };
+
+    CriticalSection processLock;
+    std::atomic<int> processIsSuspended { 0 };
+    std::atomic<bool> offlineProcessing { false };
+};
+
+} // namespace yup

--- a/modules/yup_audio_processors/processors/yup_AudioSpec.h
+++ b/modules/yup_audio_processors/processors/yup_AudioSpec.h
@@ -1,0 +1,63 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+/**
+    The audio domain specification for configuring an audio processor, including sample
+    rate, maximum block size, and number of channels.
+
+    @see AudioProcessor, DomainProcessor
+*/
+class AudioSpec
+{
+public:
+    /** Creates an AudioSpec with the given sample rate, maximum block size, and number of channels.
+
+        When configuring an AudioProcessor, the sample rate and maximum block size should be set
+        to the values provided by the host or audio engine. The number of channels should be set
+        to the maximum number of channels that the processor will handle, which may be determined by
+        the bus layout or other factors.
+
+        @param sampleRate The sample rate in Hz (e.g., 44100.0f).
+        @param maxBlockSize The maximum block size in samples (e.g., 1024).
+        @param numChannels The number of channels (e.g., 2 for stereo).
+    */
+    AudioSpec (float sampleRate, int maxBlockSize, int numChannels = 2)
+        : sampleRate (sampleRate)
+        , maxBlockSize (maxBlockSize)
+        , numChannels (numChannels)
+    {
+    }
+
+    /** Returns the sample rate in Hz. */
+    float sampleRate = 44100.0f;
+
+    /** Returns the maximum block size in samples. */
+    int maxBlockSize = 1024;
+
+    /** Returns the number of channels. */
+    int numChannels = 2;
+};
+
+} // namespace yup

--- a/modules/yup_audio_processors/processors/yup_DomainProcessor.h
+++ b/modules/yup_audio_processors/processors/yup_DomainProcessor.h
@@ -1,0 +1,142 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2024 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+/**
+    Base class for all audio processors.
+
+    The AudioProcessor class is the base class for all audio processing modules in the framework.
+    It provides a common interface for processing audio and MIDI data, managing parameters, and
+    communicating with hosts.
+
+    @see AudioProcessorEditor
+*/
+template <
+    template <typename FloatType> class DomainProcessContext,
+    class DomainSpecification>
+class YUP_API DomainProcessor : public AudioProcessorBase
+{
+public:
+    //==============================================================================
+    /** The floating-point precision used for processBlock() calls. */
+    enum class ProcessingPrecision
+    {
+        singlePrecision,
+        doublePrecision
+    };
+
+    //==============================================================================
+    /** Constructs a DomainProcessor. */
+    DomainProcessor (StringRef name)
+        : AudioProcessorBase (name)
+    {
+    }
+
+    /** Destructs a DomainProcessor. */
+    ~DomainProcessor() override = default;
+
+    //==============================================================================
+    /** Prepares the processor for playback.
+
+        The DomainSpecification provides all necessary information for initialization.
+        Subclasses do not need to call the base class.
+    */
+    virtual void prepareToPlay (const DomainSpecification& spec) = 0;
+
+    /** Releases resources. */
+    virtual void releaseResources() = 0;
+
+    /**
+        Primary single-precision processing entry point.
+
+        Override this to process a block of audio and MIDI. The context provides
+        sample-accurate parameter automation via @c context.params and the transport
+        state via @c context.playHead when available.
+
+        The base-class implementation asserts false so unoverridden processors are
+        caught at runtime in debug builds.
+
+        @param context  All per-block inputs: audio, MIDI, parameter changes, and position.
+    */
+    virtual void processBlock (DomainProcessContext<float>& context) = 0;
+
+    /**
+        Double-precision processing entry point.
+
+        Override this and return true from supportsDoublePrecisionProcessing() to
+        support 64-bit audio. The default implementation does nothing.
+
+        @param context  All per-block inputs with double-precision audio.
+    */
+    virtual void processBlock (DomainProcessContext<double>& context) { ignoreUnused (context); }
+
+    /**
+        Called by plugin wrappers when the processor is bypassed (single-precision).
+
+        The default implementation routes inputs to outputs, or clears extra outputs.
+
+        @param context  All per-block inputs.
+    */
+    virtual void processBlockBypassed (DomainProcessContext<float>& context) { ignoreUnused (context); }
+
+    /**
+        Called by plugin wrappers when the processor is bypassed (double-precision).
+
+        The default implementation routes inputs to outputs, or clears extra outputs.
+
+        @param context  All per-block inputs.
+    */
+    virtual void processBlockBypassed (DomainProcessContext<double>& context) { ignoreUnused (context); }
+
+    /** Flushes the processor. */
+    virtual void flush() {}
+
+    //==============================================================================
+    /** Returns true if this processor implements the double-precision processBlock(). */
+    virtual bool supportsDoublePrecisionProcessing() const { return false; }
+
+    /** Sets the preferred processing precision for future processBlock() calls. */
+    void setProcessingPrecision (ProcessingPrecision precision)
+    {
+        if (precision == ProcessingPrecision::doublePrecision && ! supportsDoublePrecisionProcessing())
+        {
+            jassertfalse;
+            processingPrecision = ProcessingPrecision::singlePrecision;
+            return;
+        }
+
+        processingPrecision = precision;
+    }
+
+    /** Returns the current processing precision. */
+    ProcessingPrecision getProcessingPrecision() const noexcept { return processingPrecision; }
+
+    /** Returns true when the current processing precision is double precision. */
+    bool isUsingDoublePrecision() const noexcept { return processingPrecision == ProcessingPrecision::doublePrecision; }
+
+private:
+    ProcessingPrecision processingPrecision = ProcessingPrecision::singlePrecision;
+};
+
+} // namespace yup

--- a/modules/yup_audio_processors/spectral/yup_SpectralBridge.cpp
+++ b/modules/yup_audio_processors/spectral/yup_SpectralBridge.cpp
@@ -1,0 +1,447 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+SpectralBridge::SpectralBridge (StringRef name, AudioBusLayout busLayout)
+    : AudioProcessor (name, std::move (busLayout))
+{
+    allocateResources();
+    setLatencySamples (fftSize);
+}
+
+SpectralBridge::~SpectralBridge() = default;
+
+//==============================================================================
+void SpectralBridge::setSpectralProcessor (std::shared_ptr<SpectralProcessor> processor)
+{
+    spectralProcessor = std::move (processor);
+
+    if (spectralProcessor != nullptr)
+    {
+        for (auto& param : spectralProcessor->getParameters())
+            addParameter (param);
+    }
+}
+
+std::shared_ptr<SpectralProcessor> SpectralBridge::getSpectralProcessor() const noexcept
+{
+    return spectralProcessor;
+}
+
+//==============================================================================
+void SpectralBridge::setFFTSize (int newFFTSize)
+{
+    jassert (newFFTSize > 0 && (newFFTSize & (newFFTSize - 1)) == 0);
+
+    if (newFFTSize == fftSize)
+        return;
+
+    auto suspension = ScopedProcessSuspension (*this, false);
+    if (isPrepared())
+        suspension.setSuspended();
+
+    fftSize = newFFTSize;
+    hopSize = fftSize / overlapFactor;
+    numBins = fftSize / 2 + 1;
+
+    reconfigureIfPrepared();
+    setLatencySamples (fftSize);
+}
+
+int SpectralBridge::getFFTSize() const noexcept
+{
+    return fftSize;
+}
+
+//==============================================================================
+void SpectralBridge::setOverlapFactor (int newOverlapFactor)
+{
+    jassert (newOverlapFactor >= 1);
+
+    if (newOverlapFactor == overlapFactor)
+        return;
+
+    auto suspension = ScopedProcessSuspension (*this, false);
+    if (isPrepared())
+        suspension.setSuspended();
+
+    overlapFactor = newOverlapFactor;
+    hopSize = fftSize / overlapFactor;
+
+    reconfigureIfPrepared();
+}
+
+int SpectralBridge::getOverlapFactor() const noexcept
+{
+    return overlapFactor;
+}
+
+//==============================================================================
+void SpectralBridge::setWindowType (WindowType type)
+{
+    if (windowType == type)
+        return;
+
+    auto suspension = ScopedProcessSuspension (*this, false);
+    if (isPrepared())
+        suspension.setSuspended();
+
+    windowType = type;
+    reconfigureIfPrepared();
+}
+
+WindowType SpectralBridge::getWindowType() const noexcept
+{
+    return windowType;
+}
+
+//==============================================================================
+void SpectralBridge::setWindowParameter (float parameter)
+{
+    if (windowParameter == parameter)
+        return;
+
+    auto suspension = ScopedProcessSuspension (*this, false);
+    if (isPrepared())
+        suspension.setSuspended();
+
+    windowParameter = parameter;
+    reconfigureIfPrepared();
+}
+
+float SpectralBridge::getWindowParameter() const noexcept
+{
+    return windowParameter;
+}
+
+//==============================================================================
+void SpectralBridge::prepareToPlay (const AudioSpec& spec)
+{
+    const float rate = jmax (1.0f, spec.sampleRate);
+    const int blockSize = jmax (1, spec.maxBlockSize);
+
+    AudioProcessorBase::setPlaybackConfiguration (rate, blockSize);
+
+    allocateResources();
+    setLatencySamples (fftSize);
+
+    if (spectralProcessor != nullptr)
+    {
+        const auto spectralSpec = SpectralSpec (getSampleRate(), getSamplesPerBlock(), static_cast<int> (channelState.size()), fftSize);
+        spectralProcessor->prepareToPlay (spectralSpec);
+    }
+
+    spectralParams.reserve (512);
+}
+
+void SpectralBridge::releaseResources()
+{
+    for (auto& ch : channelState)
+        ch = {};
+
+    window = {};
+    colaCompensation = {};
+    spectralBuffer = {};
+
+    fftSize = 1024;
+    hopSize = 256;
+    numBins = 0;
+    overlapFactor = 4;
+
+    if (spectralProcessor != nullptr)
+        spectralProcessor->releaseResources();
+}
+
+//==============================================================================
+void SpectralBridge::flush()
+{
+    for (auto& ch : channelState)
+    {
+        std::fill (ch.inputRing.begin(), ch.inputRing.end(), 0.0f);
+        std::fill (ch.outputRing.begin(), ch.outputRing.end(), 0.0f);
+        std::fill (ch.workBuf.begin(), ch.workBuf.end(), 0.0f);
+
+        ch.samplesWritten = 0;
+        ch.nextFrameStart = 0;
+    }
+
+    if (spectralProcessor != nullptr)
+        spectralProcessor->flush();
+}
+
+//==============================================================================
+void SpectralBridge::processBlock (AudioProcessContext<float>& context)
+{
+    if (fftSize <= 0 || hopSize <= 0 || fft.getSize() != fftSize)
+        return;
+
+    auto& audioBuffer = context.audio;
+    const int numSamples = audioBuffer.getNumSamples();
+    if (numSamples <= 0)
+        return;
+
+    jassert (numSamples <= getSamplesPerBlock());
+    if (numSamples > getSamplesPerBlock())
+        return;
+
+    const ScopedTryLock lock (getProcessLock());
+    if (! lock.isLocked())
+    {
+        context.audio.clear();
+        return;
+    }
+
+    if (isSuspended())
+    {
+        context.audio.clear();
+        return;
+    }
+
+    const int numChannels = jmin (audioBuffer.getNumChannels(), static_cast<int> (channelState.size()));
+
+    const int64 blockStart = channelState[0].samplesWritten;
+    const int64 blockEnd = blockStart + static_cast<int64> (numSamples);
+
+    for (size_t ch = 0; ch < channelState.size(); ++ch)
+    {
+        auto& st = channelState[ch];
+
+        if (st.inputRing.empty())
+            continue;
+
+        const int inputRingSize = static_cast<int> (st.inputRing.size());
+        const auto* readPtr = ch < static_cast<size_t> (numChannels)
+                                ? audioBuffer.getReadPointer (static_cast<int> (ch))
+                                : nullptr;
+
+        for (int s = 0; s < numSamples; ++s)
+        {
+            const float sample = readPtr != nullptr ? readPtr[s] : 0.0f;
+            st.inputRing[wrapIndex (blockStart + static_cast<int64> (s), inputRingSize)] = sample;
+        }
+
+        st.samplesWritten = blockEnd;
+    }
+
+    processAvailableFrames (context);
+
+    for (int ch = 0; ch < numChannels; ++ch)
+    {
+        auto& st = channelState[static_cast<size_t> (ch)];
+
+        auto* writePtr = audioBuffer.getWritePointer (ch);
+        if (writePtr == nullptr || st.outputRing.empty())
+            continue;
+
+        const int outputRingSize = static_cast<int> (st.outputRing.size());
+
+        for (int s = 0; s < numSamples; ++s)
+        {
+            const int64 outputPosition = blockStart + static_cast<int64> (s);
+            const size_t outputIndex = wrapIndex (outputPosition, outputRingSize);
+
+            writePtr[s] = st.outputRing[outputIndex];
+            st.outputRing[outputIndex] = 0.0f;
+        }
+    }
+}
+
+//==============================================================================
+bool SpectralBridge::hasEditor() const { return false; }
+
+int SpectralBridge::getCurrentPreset() const noexcept { return 0; }
+
+void SpectralBridge::setCurrentPreset (int) noexcept {}
+
+int SpectralBridge::getNumPresets() const { return 0; }
+
+String SpectralBridge::getPresetName (int) const { return {}; }
+
+void SpectralBridge::setPresetName (int, StringRef) {}
+
+bool SpectralBridge::supportsDataTreeState() const noexcept { return true; }
+
+Result SpectralBridge::loadStateFromDataTree (const DataTree&)
+{
+    return Result::ok();
+}
+
+Result SpectralBridge::saveStateIntoDataTree (DataTree&)
+{
+    return Result::ok();
+}
+
+//==============================================================================
+void SpectralBridge::allocateResources()
+{
+    const int inputRingSize = fftSize + getSamplesPerBlock() + hopSize;
+    const int outputRingSize = fftSize * 2 + getSamplesPerBlock() * 2 + hopSize;
+
+    numBins = fftSize / 2 + 1;
+    hopSize = fftSize / overlapFactor;
+
+    fft.setSize (fftSize);
+    fft.setScaling (FFTProcessor::FFTScaling::asymmetric);
+
+    buildWindows();
+
+    const auto numChannels = static_cast<size_t> (jmax (getBusLayout().getNumAudioInputChannels(),
+                                                        getBusLayout().getNumAudioOutputChannels(),
+                                                        1));
+    channelState.resize (numChannels);
+    spectralBuffer.setSize (static_cast<int> (numChannels), numBins, false, false, false);
+
+    for (size_t ch = 0; ch < numChannels; ++ch)
+    {
+        auto& st = channelState[ch];
+
+        st.inputRing.resize (static_cast<size_t> (inputRingSize));
+        std::fill (st.inputRing.begin(), st.inputRing.end(), 0.0f);
+
+        st.outputRing.resize (static_cast<size_t> (outputRingSize));
+        std::fill (st.outputRing.begin(), st.outputRing.end(), 0.0f);
+
+        st.workBuf.resize (static_cast<size_t> (fftSize * 2));
+
+        st.samplesWritten = 0;
+        st.nextFrameStart = 0;
+    }
+}
+
+void SpectralBridge::buildWindows()
+{
+    window.resize (static_cast<size_t> (fftSize));
+    colaCompensation.resize (static_cast<size_t> (fftSize));
+
+    WindowFunctions<float>::generate (windowType, window, windowParameter);
+
+    for (int n = 0; n < fftSize; ++n)
+    {
+        float overlapSum = 0.0f;
+
+        for (int overlapIndex = n % hopSize; overlapIndex < fftSize; overlapIndex += hopSize)
+        {
+            const float w = window[static_cast<size_t> (overlapIndex)];
+            overlapSum += w * w;
+        }
+
+        colaCompensation[static_cast<size_t> (n)] = overlapSum > 0.0f
+                                                      ? window[static_cast<size_t> (n)] / overlapSum
+                                                      : 0.0f;
+    }
+}
+
+bool SpectralBridge::isPrepared() const
+{
+    return ! channelState.empty() && ! channelState[0].inputRing.empty();
+}
+
+void SpectralBridge::reconfigureIfPrepared()
+{
+    if (! isPrepared())
+        return;
+
+    flush();
+    allocateResources();
+
+    if (spectralProcessor != nullptr)
+    {
+        spectralProcessor->releaseResources();
+
+        const auto spectralSpec = SpectralSpec (getSampleRate(), getSamplesPerBlock(), static_cast<int> (channelState.size()), fftSize);
+        spectralProcessor->prepareToPlay (spectralSpec);
+    }
+
+    spectralParams.reserve (512);
+}
+
+void SpectralBridge::processAvailableFrames (AudioProcessContext<float>& context)
+{
+    ScopedNoDenormals noDenormals;
+
+    const int numChannels = jmin (context.audio.getNumChannels(), static_cast<int> (channelState.size()));
+
+    spectralParams.clear();
+
+    auto& st0 = channelState[0];
+
+    while (st0.nextFrameStart + static_cast<int64> (fftSize) <= st0.samplesWritten)
+    {
+        const int64 frameStart = st0.nextFrameStart;
+
+        for (int ch = 0; ch < numChannels; ++ch)
+        {
+            auto& st = channelState[static_cast<size_t> (ch)];
+            const int inputRingSize = static_cast<int> (st.inputRing.size());
+
+            for (int n = 0; n < fftSize; ++n)
+            {
+                const int64 inputPosition = frameStart + static_cast<int64> (n);
+                st.workBuf[static_cast<size_t> (n)] = st.inputRing[wrapIndex (inputPosition, inputRingSize)]
+                                                    * window[static_cast<size_t> (n)];
+            }
+
+            fft.performRealFFTForward (st.workBuf.data(), st.workBuf.data());
+
+            const int numBinsFloats = numBins * 2;
+            auto* specPtr = spectralBuffer.getWritePointer (ch);
+
+            std::memcpy (specPtr, st.workBuf.data(), numBinsFloats * sizeof (float));
+        }
+
+        if (spectralProcessor != nullptr)
+        {
+            SpectralProcessContext<float> spectralCtx { spectralBuffer, spectralParams };
+            spectralProcessor->processBlock (spectralCtx);
+        }
+
+        for (int ch = 0; ch < numChannels; ++ch)
+        {
+            auto& st = channelState[static_cast<size_t> (ch)];
+            const int outputRingSize = static_cast<int> (st.outputRing.size());
+
+            const int numBinsFloats = numBins * 2;
+            const auto* specPtr = spectralBuffer.getReadPointer (ch);
+
+            std::memcpy (st.workBuf.data(), specPtr, numBinsFloats * sizeof (float));
+            std::memset (st.workBuf.data() + numBinsFloats, 0, (fftSize * 2 - numBinsFloats) * sizeof (float));
+
+            fft.performRealFFTInverse (st.workBuf.data(), st.workBuf.data());
+
+            const int64 outputStart = frameStart + static_cast<int64> (fftSize);
+
+            for (int n = 0; n < fftSize; ++n)
+            {
+                const int64 outputPosition = outputStart + static_cast<int64> (n);
+                st.outputRing[wrapIndex (outputPosition, outputRingSize)] += st.workBuf[static_cast<size_t> (n)] * colaCompensation[static_cast<size_t> (n)];
+            }
+        }
+
+        const int64 nextFrameStart = frameStart + static_cast<int64> (hopSize);
+        for (auto& st : channelState)
+            st.nextFrameStart = nextFrameStart;
+    }
+}
+
+} // namespace yup

--- a/modules/yup_audio_processors/spectral/yup_SpectralBridge.h
+++ b/modules/yup_audio_processors/spectral/yup_SpectralBridge.h
@@ -1,0 +1,218 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+/**
+    A time-domain AudioProcessor that bridges to a frequency-domain SpectralProcessor
+    via STFT (Short-Time Fourier Transform) with weighted overlap-add.
+
+    The bridge performs real FFT/IFFT conversion, windowing, and overlap-add so that
+    the wrapped SpectralProcessor can operate purely in the frequency domain. Set the
+    FFT size and overlap factor to control the time-frequency resolution tradeoff.
+
+    Latency is equal to the current FFT size.
+
+    Typical usage:
+    @code
+    auto bridge = std::make_unique<SpectralBridge> ("MyBridge", AudioBusLayout { ... });
+    bridge->setFFTSize (1024);
+    bridge->setOverlapFactor (4);       // 75% overlap, hop = fftSize / 4
+    bridge->setSpectralProcessor (mySpectralProcessor);
+    bridge->prepareToPlay (AudioSpec (44100.0f, 512, 2));
+    bridge->processBlock (context);
+    @endcode
+
+    @tags{Audio, Spectral, Realtime}
+*/
+class YUP_API SpectralBridge : public AudioProcessor
+{
+public:
+    //==============================================================================
+    /** Constructs a SpectralBridge with the given name and bus layout.
+
+        @param name       The processor name.
+        @param busLayout  The input/output bus layout.
+    */
+    SpectralBridge (StringRef name, AudioBusLayout busLayout);
+
+    /** Destructor. */
+    ~SpectralBridge() override;
+
+    //==============================================================================
+    /** Assigns the spectral processor to be applied in the frequency domain.
+
+        The bridge takes shared ownership of the processor. Parameters from the
+        spectral processor are registered on the bridge so they are visible to hosts.
+
+        @param processor  The spectral processor, or nullptr to disable processing.
+    */
+    void setSpectralProcessor (std::shared_ptr<SpectralProcessor> processor);
+
+    /** Returns the current spectral processor, or nullptr. */
+    std::shared_ptr<SpectralProcessor> getSpectralProcessor() const noexcept;
+
+    //==============================================================================
+    /** Sets the FFT size (must be a power of two).
+
+        The change takes effect on the next call to prepareToPlay(). The processor
+        latency is updated immediately for host discovery.
+
+        @param fftSize  The new FFT size.
+    */
+    void setFFTSize (int fftSize);
+
+    /** Returns the current FFT size. */
+    int getFFTSize() const noexcept;
+
+    //==============================================================================
+    /** Sets the overlap factor for the STFT.
+
+        The hop size is computed as fftSize / overlapFactor. Higher values give
+        smoother time-varying effects at the cost of increased CPU usage.
+        Common values: 4 (75% overlap), 2 (50% overlap).
+
+        The change takes effect on the next call to prepareToPlay().
+
+        @param overlapFactor  The overlap factor (must be >= 1).
+    */
+    void setOverlapFactor (int overlapFactor);
+
+    /** Returns the current overlap factor. */
+    int getOverlapFactor() const noexcept;
+
+    //==============================================================================
+    /** Sets the window type used for both analysis and synthesis windowing.
+
+        The change takes effect on the next call to prepareToPlay(). The default
+        is WindowType::hann, which provides good frequency selectivity and COLA
+        properties with 75% overlap.
+
+        @param type  The window type to use.
+    */
+    void setWindowType (WindowType type);
+
+    /** Returns the current window type. */
+    WindowType getWindowType() const noexcept;
+
+    //==============================================================================
+    /** Sets an optional parameter used by parameterizable window types.
+
+        Relevant windows:
+        - Kaiser: beta (default 8.0, higher = more sidelobe attenuation)
+        - Gaussian: sigma (default 0.4, controls width)
+        - Tukey: alpha (default 0.5, taper ratio 0..1)
+        - RakshitUllah: r (default 1.0, controlling parameter)
+
+        The change takes effect on the next call to prepareToPlay().
+
+        @param parameter  The window-specific parameter value.
+    */
+    void setWindowParameter (float parameter);
+
+    /** Returns the current window parameter. */
+    float getWindowParameter() const noexcept;
+
+    //==============================================================================
+    /** @internal */
+    void prepareToPlay (const AudioSpec& spec) override;
+    /** @internal */
+    void releaseResources() override;
+    /** @internal */
+    void processBlock (AudioProcessContext<float>& context) override;
+    /** @internal */
+    void flush() override;
+
+    /** @internal */
+    int getLatencySamples() override { return fftSize; }
+
+    /** @internal */
+    bool hasEditor() const override;
+    /** @internal */
+    int getCurrentPreset() const noexcept override;
+    /** @internal */
+    void setCurrentPreset (int) noexcept override;
+    /** @internal */
+    int getNumPresets() const override;
+    /** @internal */
+    String getPresetName (int) const override;
+    /** @internal */
+    void setPresetName (int, StringRef) override;
+    /** @internal */
+    bool supportsDataTreeState() const noexcept override;
+    /** @internal */
+    Result loadStateFromDataTree (const DataTree& state) override;
+    /** @internal */
+    Result saveStateIntoDataTree (DataTree& state) override;
+
+private:
+    //==============================================================================
+    struct ChannelState
+    {
+        std::vector<float> inputRing;
+        std::vector<float> outputRing;
+        std::vector<float> workBuf;
+
+        int64 samplesWritten = 0;
+        int64 nextFrameStart = 0;
+    };
+
+    //==============================================================================
+    static size_t wrapIndex (int64 position, int size) noexcept
+    {
+        jassert (position >= 0);
+        jassert (size > 0);
+
+        return static_cast<size_t> (position % static_cast<int64> (size));
+    }
+
+    //==============================================================================
+    void allocateResources();
+    void buildWindows();
+    bool isPrepared() const;
+    void reconfigureIfPrepared();
+    void processAvailableFrames (AudioProcessContext<float>& context);
+
+    //==============================================================================
+    FFTProcessor fft;
+    std::shared_ptr<SpectralProcessor> spectralProcessor;
+    SpectralBuffer<float> spectralBuffer;
+
+    std::vector<float> window;
+    std::vector<float> colaCompensation;
+
+    int fftSize = 1024;
+    int hopSize = 256;
+    int overlapFactor = 4;
+    int numBins = 0;
+    WindowType windowType = WindowType::hann;
+    float windowParameter = 8.0f;
+
+    std::vector<ChannelState> channelState;
+
+    ParameterChangeBuffer spectralParams;
+
+    YUP_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SpectralBridge)
+};
+
+} // namespace yup

--- a/modules/yup_audio_processors/spectral/yup_SpectralProcessContext.h
+++ b/modules/yup_audio_processors/spectral/yup_SpectralProcessContext.h
@@ -1,0 +1,51 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+
+/**
+    All inputs available to a SpectralProcessor for a single processing block.
+
+    SpectralProcessContext<FloatType> is passed to SpectralProcessor::processBlock() and bundles:
+      - the spectral buffer (in-place processing model, single or double precision),
+      - sample-accurate parameter automation events, ignoring sampleOffset.
+
+    Use SpectralProcessContext<float> for the primary single-precision processing path.
+    Use SpectralProcessContext<double> for double-precision processing in processors that
+    override processBlock(SpectralProcessContext<double>&) and return true from
+    supportsDoublePrecisionProcessing().
+
+    @see SpectralProcessor, ParameterChangeBuffer, AudioParameterHandle
+*/
+template <typename FloatType>
+struct SpectralProcessContext
+{
+    /** Raw bins buffer in contiguous [real, imag] pairs per channel. Process in-place: read and write the same channels. */
+    SpectralBuffer<FloatType>& bins;
+
+    /** Parameter automation events for this block, ignoring sampleOffset. */
+    ParameterChangeBuffer& params;
+};
+
+} // namespace yup

--- a/modules/yup_audio_processors/spectral/yup_SpectralProcessor.cpp
+++ b/modules/yup_audio_processors/spectral/yup_SpectralProcessor.cpp
@@ -24,7 +24,7 @@ namespace yup
 
 //==============================================================================
 
-AudioProcessor::AudioProcessor (StringRef name, AudioBusLayout busLayout)
+SpectralProcessor::SpectralProcessor (StringRef name, AudioBusLayout busLayout)
     : BaseDomainProcessor (name)
     , busLayout (std::move (busLayout))
 {
@@ -32,11 +32,11 @@ AudioProcessor::AudioProcessor (StringRef name, AudioBusLayout busLayout)
 
 //==============================================================================
 
-AudioProcessor::~AudioProcessor() = default;
+SpectralProcessor::~SpectralProcessor() = default;
 
 //==============================================================================
 
-int AudioProcessor::getNumAudioOutputs() const
+int SpectralProcessor::getNumAudioOutputs() const
 {
     int count = 0;
 
@@ -47,7 +47,7 @@ int AudioProcessor::getNumAudioOutputs() const
     return count;
 }
 
-int AudioProcessor::getNumAudioInputs() const
+int SpectralProcessor::getNumAudioInputs() const
 {
     int count = 0;
 
@@ -60,7 +60,7 @@ int AudioProcessor::getNumAudioInputs() const
 
 //==============================================================================
 
-bool AudioProcessor::acceptsMidi() const noexcept
+bool SpectralProcessor::acceptsMidi() const noexcept
 {
     for (const auto& bus : busLayout.getInputBuses())
         if (bus.getType() == AudioBus::Type::Midi)
@@ -69,7 +69,7 @@ bool AudioProcessor::acceptsMidi() const noexcept
     return false;
 }
 
-bool AudioProcessor::producesMidi() const noexcept
+bool SpectralProcessor::producesMidi() const noexcept
 {
     for (const auto& bus : busLayout.getOutputBuses())
         if (bus.getType() == AudioBus::Type::Midi)
@@ -80,21 +80,23 @@ bool AudioProcessor::producesMidi() const noexcept
 
 //==============================================================================
 
-AudioProcessorEditor* AudioProcessor::createEditor()
+/*
+AudioProcessorEditor* SpectralProcessor::createEditor()
 {
     jassert (hasEditor());
     return nullptr;
 }
+*/
 
 //==============================================================================
 
-void AudioProcessor::setPlaybackConfiguration (float sampleRate, int samplesPerBlock)
+void SpectralProcessor::setPlaybackConfiguration (float sampleRate, int samplesPerBlock)
 {
     releaseResources();
 
     AudioProcessorBase::setPlaybackConfiguration (sampleRate, samplesPerBlock);
 
-    prepareToPlay (AudioSpec (sampleRate, samplesPerBlock));
+    prepareToPlay (SpectralSpec (sampleRate, samplesPerBlock));
 }
 
 } // namespace yup

--- a/modules/yup_audio_processors/spectral/yup_SpectralProcessor.h
+++ b/modules/yup_audio_processors/spectral/yup_SpectralProcessor.h
@@ -22,29 +22,27 @@
 namespace yup
 {
 
-class AudioProcessorEditor;
-
 //==============================================================================
 /**
-    Base class for all audio processors.
+    Base class for all spectral processors.
 
-    The AudioProcessor class is the base class for all audio processing modules in the framework.
-    It provides a common interface for processing audio and MIDI data, managing parameters, and
+    The SpectralProcessor class is the base class for all spectral processing modules in the framework.
+    It provides a common interface for processing spectral bins, managing parameters, and
     communicating with hosts.
 
     @see AudioProcessorEditor
 */
-class YUP_API AudioProcessor : public DomainProcessor<AudioProcessContext, AudioSpec>
+class YUP_API SpectralProcessor : public DomainProcessor<SpectralProcessContext, SpectralSpec>
 {
-    using BaseDomainProcessor = DomainProcessor<AudioProcessContext, AudioSpec>;
+    using BaseDomainProcessor = DomainProcessor<SpectralProcessContext, SpectralSpec>;
 
 public:
     //==============================================================================
-    /** Constructs an AudioProcessor. */
-    AudioProcessor (StringRef name, AudioBusLayout busLayout);
+    /** Constructs a SpectralProcessor. */
+    SpectralProcessor (StringRef name, AudioBusLayout busLayout);
 
-    /** Destructs an AudioProcessor. */
-    ~AudioProcessor() override;
+    /** Destructs a SpectralProcessor. */
+    ~SpectralProcessor() override;
 
     //==============================================================================
     /** Returns the bus layout. */
@@ -62,18 +60,6 @@ public:
 
     /** Returns true if the processor produces MIDI output. */
     virtual bool producesMidi() const noexcept;
-
-    //==============================================================================
-    /** Returns the number of simultaneous voices this processor can produce.
-        Returns 0 for effects and MIDI-only processors. Override in instruments. */
-    virtual int getNumVoices() const { return 0; }
-
-    //==============================================================================
-    /** Returns true if the processor has an editor. */
-    virtual bool hasEditor() const = 0;
-
-    /** Creates an editor for the processor. */
-    virtual AudioProcessorEditor* createEditor();
 
     //==============================================================================
     /** @internal Used by plugin wrappers. */

--- a/modules/yup_audio_processors/spectral/yup_SpectralSpec.h
+++ b/modules/yup_audio_processors/spectral/yup_SpectralSpec.h
@@ -1,0 +1,63 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2025 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+/**
+    The audio domain specification for configuring an audio processor, including sample
+    rate and maximum block size.
+
+    @see SpectralProcessor, DomainProcessor
+*/
+class SpectralSpec
+{
+public:
+    /** Creates a SpectralSpec with the given sample rate and maximum block size.
+    
+        @param sampleRate The sample rate in Hz (e.g., 44100.0f).
+        @param maxBlockSize The maximum block size in samples (e.g., 1024).
+        @param numChannels The number of channels (e.g., 2 for stereo).            
+        @param fftSize The FFT size in samples (e.g., 2048).
+    */
+    SpectralSpec (float sampleRate, int maxBlockSize, int numChannels = 2, int fftSize = 2048)
+        : sampleRate (sampleRate)
+        , maxBlockSize (maxBlockSize)
+        , numChannels (numChannels)
+        , fftSize (fftSize)
+    {
+    }
+
+    /** Returns the sample rate in Hz. */
+    float sampleRate = 44100.0f;
+
+    /** Returns the maximum block size in samples. */
+    int maxBlockSize = 1024;
+
+    /** Returns the number of channels. */
+    int numChannels = 2;
+
+    /** Returns the FFT size in samples. */
+    int fftSize = 2048;
+};
+
+} // namespace yup

--- a/modules/yup_audio_processors/yup_audio_processors.cpp
+++ b/modules/yup_audio_processors/yup_audio_processors.cpp
@@ -33,7 +33,10 @@
 //==============================================================================
 #include "processors/yup_AudioParameter.cpp"
 #include "processors/yup_AudioParameterBuilder.cpp"
+#include "processors/yup_AudioProcessorBase.cpp"
 #include "processors/yup_AudioProcessor.cpp"
+#include "spectral/yup_SpectralProcessor.cpp"
+#include "spectral/yup_SpectralBridge.cpp"
 
 #if YUP_MODULE_AVAILABLE_yup_gui
 #include "processors/yup_AudioProcessorEditor.cpp"

--- a/modules/yup_audio_processors/yup_audio_processors.h
+++ b/modules/yup_audio_processors/yup_audio_processors.h
@@ -32,7 +32,7 @@
     website:            https://github.com/kunitoki/yup
     license:            ISC
 
-    dependencies:       yup_audio_basics yup_data_model
+    dependencies:       yup_audio_basics yup_data_model yup_dsp
 
   END_YUP_MODULE_DECLARATION
 
@@ -46,6 +46,7 @@
 
 #include <yup_audio_basics/yup_audio_basics.h>
 #include <yup_data_model/yup_data_model.h>
+#include <yup_dsp/yup_dsp.h>
 
 #if YUP_MODULE_AVAILABLE_yup_gui
 #include <yup_gui/yup_gui.h>
@@ -57,9 +58,16 @@
 #include "processors/yup_AudioParameter.h"
 #include "processors/yup_AudioParameterBuilder.h"
 #include "processors/yup_ParameterChangeBuffer.h"
-#include "processors/yup_AudioProcessContext.h"
 #include "processors/yup_AudioParameterHandle.h"
+#include "processors/yup_AudioProcessorBase.h"
+#include "processors/yup_DomainProcessor.h"
+#include "processors/yup_AudioSpec.h"
+#include "processors/yup_AudioProcessContext.h"
 #include "processors/yup_AudioProcessor.h"
+#include "spectral/yup_SpectralSpec.h"
+#include "spectral/yup_SpectralProcessContext.h"
+#include "spectral/yup_SpectralProcessor.h"
+#include "spectral/yup_SpectralBridge.h"
 
 #if YUP_MODULE_AVAILABLE_yup_gui
 #include "processors/yup_AudioProcessorEditor.h"

--- a/modules/yup_dsp/resampling/yup_Resampler.h
+++ b/modules/yup_dsp/resampling/yup_Resampler.h
@@ -154,7 +154,7 @@ public:
             }
         }
 
-        const int outputCount = static_cast<int> ((numSamples - currentPhase) * oversampleFactor);
+        const int outputCount = static_cast<int> (std::ceil ((numSamples - currentPhase) * oversampleFactor));
         const CoeffType gainScale = (oversampleFactor < 1.0)
                                       ? static_cast<CoeffType> (oversampleFactor)
                                       : CoeffType (1);
@@ -202,7 +202,7 @@ public:
                 endBufs[static_cast<std::size_t> (ch)].push (xBuf[static_cast<std::size_t> (numSamples + i)]);
         }
 
-        currentPhase = (currentPhase + static_cast<double> (outputCount) / oversampleFactor) - numSamples;
+        currentPhase = std::max (0.0, (currentPhase + static_cast<double> (outputCount) / oversampleFactor) - numSamples);
         return outputCount;
     }
 

--- a/modules/yup_dsp/yup_dsp.cpp
+++ b/modules/yup_dsp/yup_dsp.cpp
@@ -68,7 +68,7 @@
 #endif
 
 #if ! YUP_FFT_FOUND_BACKEND && YUP_ENABLE_OOURA
-#include "yup_OouraFFT8g.h"
+#include "frequency/yup_OouraFFT8g.h"
 #define YUP_FFT_USING_OOURA 1
 #define YUP_FFT_FOUND_BACKEND 1
 #endif

--- a/tests/yup_audio_basics.cpp
+++ b/tests/yup_audio_basics.cpp
@@ -25,6 +25,7 @@
 #include "yup_audio_basics/yup_AudioPlayHead.cpp"
 #include "yup_audio_basics/yup_AudioProcessLoadMeasurer.cpp"
 #include "yup_audio_basics/yup_AudioSampleBuffer.cpp"
+#include "yup_audio_basics/yup_AudioSpectralBuffer.cpp"
 #include "yup_audio_basics/yup_BufferingAudioSource.cpp"
 #include "yup_audio_basics/yup_ChannelRemappingAudioSource.cpp"
 #include "yup_audio_basics/yup_Decibels.cpp"

--- a/tests/yup_audio_basics/yup_AudioSpectralBuffer.cpp
+++ b/tests/yup_audio_basics/yup_AudioSpectralBuffer.cpp
@@ -1,0 +1,599 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include <gtest/gtest.h>
+
+#include <yup_audio_basics/yup_audio_basics.h>
+
+#include <cmath>
+#include <algorithm>
+#include <vector>
+#include <cstring>
+
+using namespace yup;
+
+template <class T>
+class AudioSpectralBufferTests : public ::testing::Test
+{
+public:
+    using BufferType = SpectralBuffer<T>;
+
+protected:
+    void fillChannel (BufferType& buffer, int channel, T startReal, T startImag)
+    {
+        auto* ptr = buffer.getWritePointer (channel);
+        const auto numBins = buffer.getNumBins();
+
+        for (int i = 0; i < numBins; ++i)
+        {
+            ptr[i * 2] = startReal + static_cast<T> (i);
+            ptr[i * 2 + 1] = startImag + static_cast<T> (i);
+        }
+    }
+
+    void fillRamp (BufferType& buffer)
+    {
+        for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+            fillChannel (buffer, ch, static_cast<T> (ch * 100), static_cast<T> (ch * 100 + 50));
+    }
+
+    bool pointersAreEqual (const T* a, const T* b, int numFloats)
+    {
+        for (int i = 0; i < numFloats; ++i)
+        {
+            if (! approximatelyEqual (a[i], b[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    T magnitude (T real, T imag) const
+    {
+        return std::sqrt (real * real + imag * imag);
+    }
+};
+
+using FloatTypes = ::testing::Types<float, double>;
+TYPED_TEST_SUITE (AudioSpectralBufferTests, FloatTypes);
+
+//==============================================================================
+// Default constructor
+TYPED_TEST (AudioSpectralBufferTests, DefaultConstructor)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer;
+    EXPECT_EQ (buffer.getNumChannels(), 0);
+    EXPECT_EQ (buffer.getNumBins(), 0);
+    EXPECT_TRUE (buffer.hasBeenCleared());
+}
+
+//==============================================================================
+// Constructor with channels and bins
+TYPED_TEST (AudioSpectralBufferTests, ConstructorWithChannelsAndBins)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    constexpr int channels = 2;
+    constexpr int bins = 128;
+    BufferType buffer (channels, bins);
+    EXPECT_EQ (buffer.getNumChannels(), channels);
+    EXPECT_EQ (buffer.getNumBins(), bins);
+    EXPECT_FALSE (buffer.hasBeenCleared());
+
+    for (int ch = 0; ch < channels; ++ch)
+    {
+        const TypeParam* readPtr = buffer.getReadPointer (ch);
+        EXPECT_NE (readPtr, nullptr);
+    }
+}
+
+//==============================================================================
+// clear and hasBeenCleared
+TYPED_TEST (AudioSpectralBufferTests, ClearSetsAllBinsToZero)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 64);
+    this->fillRamp (buffer);
+    EXPECT_FALSE (buffer.hasBeenCleared());
+
+    buffer.clear();
+    EXPECT_TRUE (buffer.hasBeenCleared());
+
+    for (int ch = 0; ch < buffer.getNumChannels(); ++ch)
+    {
+        const auto* ptr = buffer.getReadPointer (ch);
+        for (int i = 0; i < buffer.getNumBins() * 2; ++i)
+            EXPECT_EQ (ptr[i], TypeParam (0));
+    }
+}
+
+TYPED_TEST (AudioSpectralBufferTests, ClearIsNoopWhenAlreadyCleared)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 64);
+    buffer.clear();
+    EXPECT_TRUE (buffer.hasBeenCleared());
+    buffer.clear(); // should be a no-op
+    EXPECT_TRUE (buffer.hasBeenCleared());
+}
+
+TYPED_TEST (AudioSpectralBufferTests, SetNotClearResetsFlag)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 64);
+    buffer.clear();
+    EXPECT_TRUE (buffer.hasBeenCleared());
+
+    buffer.setNotClear();
+    EXPECT_FALSE (buffer.hasBeenCleared());
+}
+
+//==============================================================================
+// getWritePointer / getReadPointer
+TYPED_TEST (AudioSpectralBufferTests, WritePointerMarksBufferAsNotClear)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 64);
+    buffer.clear();
+    EXPECT_TRUE (buffer.hasBeenCleared());
+
+    [[maybe_unused]] auto* ptr = buffer.getWritePointer (0);
+    EXPECT_FALSE (buffer.hasBeenCleared());
+}
+
+TYPED_TEST (AudioSpectralBufferTests, WriteAndReadThroughPointers)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 32);
+
+    auto* wPtr = buffer.getWritePointer (0);
+    for (int i = 0; i < buffer.getNumBins() * 2; ++i)
+        wPtr[i] = static_cast<TypeParam> (i + 1);
+
+    const auto* rPtr = buffer.getReadPointer (0);
+    for (int i = 0; i < buffer.getNumBins() * 2; ++i)
+        EXPECT_EQ (rPtr[i], static_cast<TypeParam> (i + 1));
+}
+
+TYPED_TEST (AudioSpectralBufferTests, WritePointerReturnInterleavedLayout)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (1, 4);
+
+    auto* ptr = buffer.getWritePointer (0);
+    ptr[0] = TypeParam (10); // bin 0 real
+    ptr[1] = TypeParam (20); // bin 0 imag
+    ptr[2] = TypeParam (30); // bin 1 real
+    ptr[3] = TypeParam (40); // bin 1 imag
+
+    EXPECT_EQ (ptr[0], TypeParam (10));
+    EXPECT_EQ (ptr[1], TypeParam (20));
+    EXPECT_EQ (ptr[2], TypeParam (30));
+    EXPECT_EQ (ptr[3], TypeParam (40));
+}
+
+//==============================================================================
+// BinRef access
+TYPED_TEST (AudioSpectralBufferTests, BinRefReadWrite)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (1, 4);
+
+    auto bin0 = buffer.getBinRef (0, 0);
+    bin0.real() = TypeParam (3);
+    bin0.imag() = TypeParam (4);
+
+    EXPECT_EQ (bin0.real(), TypeParam (3));
+    EXPECT_EQ (bin0.imag(), TypeParam (4));
+}
+
+TYPED_TEST (AudioSpectralBufferTests, BinRefSet)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (1, 4);
+    auto bin2 = buffer.getBinRef (0, 2);
+    bin2.set (TypeParam (7), TypeParam (8));
+
+    EXPECT_EQ (bin2.real(), TypeParam (7));
+    EXPECT_EQ (bin2.imag(), TypeParam (8));
+}
+
+TYPED_TEST (AudioSpectralBufferTests, BinRefMagnitude)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (1, 4);
+    auto bin = buffer.getBinRef (0, 0);
+    bin.set (TypeParam (3), TypeParam (4));
+
+    const auto expectedMag = this->magnitude (TypeParam (3), TypeParam (4));
+    EXPECT_NEAR (bin.magnitude(), expectedMag, static_cast<TypeParam> (1e-6));
+}
+
+TYPED_TEST (AudioSpectralBufferTests, BinRefPhase)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (1, 4);
+    auto bin = buffer.getBinRef (0, 0);
+    bin.set (TypeParam (1), TypeParam (1));
+
+    const auto expectedPhase = std::atan2 (TypeParam (1), TypeParam (1));
+    EXPECT_NEAR (bin.phase(), expectedPhase, static_cast<TypeParam> (1e-6));
+}
+
+TYPED_TEST (AudioSpectralBufferTests, BinRefPointsToCorrectData)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 8);
+    auto* raw = buffer.getWritePointer (1);
+
+    raw[6] = TypeParam (42); // bin 3 real (channel1, bin3)
+    raw[7] = TypeParam (99); // bin 3 imag
+
+    auto bin = buffer.getBinRef (1, 3);
+    EXPECT_EQ (bin.real(), TypeParam (42));
+    EXPECT_EQ (bin.imag(), TypeParam (99));
+}
+
+//==============================================================================
+// copyFrom (simple)
+TYPED_TEST (AudioSpectralBufferTests, CopyFromSimple)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType source (2, 32);
+    this->fillChannel (source, 0, TypeParam (10), TypeParam (20));
+    this->fillChannel (source, 1, TypeParam (30), TypeParam (40));
+
+    BufferType dest (2, 32);
+    dest.clear();
+
+    dest.copyFrom (0, source, 0);
+    dest.copyFrom (1, source, 1);
+
+    const auto* srcPtr0 = source.getReadPointer (0);
+    const auto* dstPtr0 = dest.getReadPointer (0);
+    const auto* srcPtr1 = source.getReadPointer (1);
+    const auto* dstPtr1 = dest.getReadPointer (1);
+
+    EXPECT_TRUE (this->pointersAreEqual (srcPtr0, dstPtr0, 64));
+    EXPECT_TRUE (this->pointersAreEqual (srcPtr1, dstPtr1, 64));
+}
+
+TYPED_TEST (AudioSpectralBufferTests, CopyFromSimpleDifferentChannels)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType source (2, 16);
+    this->fillChannel (source, 0, TypeParam (1), TypeParam (2));
+    this->fillChannel (source, 1, TypeParam (3), TypeParam (4));
+
+    BufferType dest (2, 16);
+    dest.copyFrom (1, source, 0);
+
+    const auto* srcPtr = source.getReadPointer (0);
+    const auto* dstPtr = dest.getReadPointer (1);
+
+    EXPECT_TRUE (this->pointersAreEqual (srcPtr, dstPtr, 32));
+}
+
+//==============================================================================
+// copyFrom (ranged)
+TYPED_TEST (AudioSpectralBufferTests, CopyFromRanged)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType source (1, 16);
+    this->fillChannel (source, 0, TypeParam (10), TypeParam (20));
+
+    BufferType dest (1, 16);
+    dest.clear();
+
+    constexpr int startBin = 4;
+    constexpr int numBins = 4;
+    dest.copyFrom (0, startBin, source, 0, 0, numBins);
+
+    const auto* srcPtr = source.getReadPointer (0);
+    const auto* dstPtr = dest.getReadPointer (0);
+
+    // first 4 bins should be zero
+    for (int i = 0; i < startBin * 2; ++i)
+        EXPECT_EQ (dstPtr[i], TypeParam (0));
+
+    // copied range
+    for (int i = 0; i < numBins * 2; ++i)
+        EXPECT_EQ (dstPtr[startBin * 2 + i], srcPtr[i]);
+
+    // remainder should be zero
+    for (int i = (startBin + numBins) * 2; i < 16 * 2; ++i)
+        EXPECT_EQ (dstPtr[i], TypeParam (0));
+}
+
+TYPED_TEST (AudioSpectralBufferTests, CopyFromRangedWithNonZeroSourceStart)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType source (1, 16);
+    this->fillChannel (source, 0, TypeParam (10), TypeParam (20));
+
+    BufferType dest (1, 16);
+    dest.clear();
+
+    constexpr int srcStartBin = 8;
+    constexpr int numBins = 4;
+    dest.copyFrom (0, 0, source, 0, srcStartBin, numBins);
+
+    const auto* srcPtr = source.getReadPointer (0);
+    const auto* dstPtr = dest.getReadPointer (0);
+
+    for (int i = 0; i < numBins; ++i)
+    {
+        const auto srcIdx = (srcStartBin + i) * 2;
+        const auto dstIdx = i * 2;
+
+        EXPECT_EQ (dstPtr[dstIdx], srcPtr[srcIdx]);
+        EXPECT_EQ (dstPtr[dstIdx + 1], srcPtr[srcIdx + 1]);
+    }
+}
+
+//==============================================================================
+// fill
+TYPED_TEST (AudioSpectralBufferTests, FillSingleChannel)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 8);
+    buffer.fill (0, TypeParam (5), TypeParam (6));
+
+    const auto* ptr = buffer.getReadPointer (0);
+    for (int i = 0; i < 8; ++i)
+    {
+        EXPECT_EQ (ptr[i * 2], TypeParam (5));
+        EXPECT_EQ (ptr[i * 2 + 1], TypeParam (6));
+    }
+}
+
+TYPED_TEST (AudioSpectralBufferTests, FillAllChannels)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (3, 4);
+    buffer.fill (TypeParam (7), TypeParam (8));
+
+    for (int ch = 0; ch < 3; ++ch)
+    {
+        const auto* ptr = buffer.getReadPointer (ch);
+        for (int i = 0; i < 4; ++i)
+        {
+            EXPECT_EQ (ptr[i * 2], TypeParam (7));
+            EXPECT_EQ (ptr[i * 2 + 1], TypeParam (8));
+        }
+    }
+}
+
+//==============================================================================
+// setSize
+TYPED_TEST (AudioSpectralBufferTests, SetSizeGrow)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (1, 8);
+    this->fillChannel (buffer, 0, TypeParam (1), TypeParam (2));
+
+    buffer.setSize (2, 16, false, true, false);
+
+    EXPECT_EQ (buffer.getNumChannels(), 2);
+    EXPECT_EQ (buffer.getNumBins(), 16);
+}
+
+TYPED_TEST (AudioSpectralBufferTests, SetSizeKeepExistingContent)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (1, 8);
+    this->fillChannel (buffer, 0, TypeParam (10), TypeParam (20));
+
+    buffer.setSize (1, 16, true, true, false);
+
+    EXPECT_EQ (buffer.getNumChannels(), 1);
+    EXPECT_EQ (buffer.getNumBins(), 16);
+
+    const auto* ptr = buffer.getReadPointer (0);
+    for (int i = 0; i < 8; ++i)
+    {
+        EXPECT_EQ (ptr[i * 2], TypeParam (10) + static_cast<TypeParam> (i));
+        EXPECT_EQ (ptr[i * 2 + 1], TypeParam (20) + static_cast<TypeParam> (i));
+    }
+}
+
+TYPED_TEST (AudioSpectralBufferTests, SetSizeShrink)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (3, 64);
+    buffer.setSize (1, 32, false, false, false);
+
+    EXPECT_EQ (buffer.getNumChannels(), 1);
+    EXPECT_EQ (buffer.getNumBins(), 32);
+}
+
+TYPED_TEST (AudioSpectralBufferTests, SetSizeNoChangeDoesNothing)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 32);
+    this->fillRamp (buffer);
+
+    buffer.setSize (2, 32); // same size
+
+    EXPECT_EQ (buffer.getNumChannels(), 2);
+    EXPECT_EQ (buffer.getNumBins(), 32);
+}
+
+//==============================================================================
+// operator== / operator!=
+TYPED_TEST (AudioSpectralBufferTests, EqualityOperator)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType a (1, 4);
+    BufferType b (1, 4);
+
+    this->fillChannel (a, 0, TypeParam (1), TypeParam (2));
+    this->fillChannel (b, 0, TypeParam (1), TypeParam (2));
+
+    EXPECT_TRUE (a == b);
+    EXPECT_FALSE (a != b);
+}
+
+TYPED_TEST (AudioSpectralBufferTests, InequalityOperator)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType a (1, 4);
+    BufferType b (1, 4);
+
+    this->fillChannel (a, 0, TypeParam (1), TypeParam (2));
+    this->fillChannel (b, 0, TypeParam (3), TypeParam (4));
+
+    EXPECT_FALSE (a == b);
+    EXPECT_TRUE (a != b);
+}
+
+TYPED_TEST (AudioSpectralBufferTests, EqualityDifferentChannels)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType a (2, 4);
+    BufferType b (1, 4);
+
+    EXPECT_FALSE (a == b);
+    EXPECT_TRUE (a != b);
+}
+
+TYPED_TEST (AudioSpectralBufferTests, EqualityDifferentBins)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType a (1, 4);
+    BufferType b (1, 8);
+
+    EXPECT_FALSE (a == b);
+    EXPECT_TRUE (a != b);
+}
+
+//==============================================================================
+// makeCopyOf
+TYPED_TEST (AudioSpectralBufferTests, MakeCopyOfSameType)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType source (2, 16);
+    this->fillRamp (source);
+
+    BufferType dest;
+    dest.makeCopyOf (source);
+
+    EXPECT_EQ (dest.getNumChannels(), source.getNumChannels());
+    EXPECT_EQ (dest.getNumBins(), source.getNumBins());
+
+    for (int ch = 0; ch < source.getNumChannels(); ++ch)
+    {
+        EXPECT_TRUE (this->pointersAreEqual (
+            source.getReadPointer (ch),
+            dest.getReadPointer (ch),
+            source.getNumBins() * 2));
+    }
+}
+
+TYPED_TEST (AudioSpectralBufferTests, MakeCopyOfClearedBuffer)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType source (1, 8);
+    source.clear();
+
+    BufferType dest;
+    dest.makeCopyOf (source);
+
+    EXPECT_TRUE (dest.hasBeenCleared());
+    EXPECT_EQ (dest.getNumBins(), 8);
+}
+
+//==============================================================================
+// getNumChannels / getNumBins on default constructed
+TYPED_TEST (AudioSpectralBufferTests, DefaultBufferHasZeroChannelsAndBins)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer;
+    EXPECT_EQ (buffer.getNumChannels(), 0);
+    EXPECT_EQ (buffer.getNumBins(), 0);
+}
+
+//==============================================================================
+// interleaved layout integrity
+TYPED_TEST (AudioSpectralBufferTests, InterleavedLayoutPreserved)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 4);
+    this->fillChannel (buffer, 0, TypeParam (1), TypeParam (2));
+    this->fillChannel (buffer, 1, TypeParam (3), TypeParam (4));
+
+    auto bin0_ch1 = buffer.getBinRef (1, 0);
+    auto bin3_ch0 = buffer.getBinRef (0, 3);
+
+    EXPECT_EQ (bin0_ch1.real(), TypeParam (3));
+    EXPECT_EQ (bin0_ch1.imag(), TypeParam (4));
+    EXPECT_EQ (bin3_ch0.real(), TypeParam (1) + TypeParam (3));
+    EXPECT_EQ (bin3_ch0.imag(), TypeParam (2) + TypeParam (3));
+}
+
+//==============================================================================
+// copyFrom self-copy within same buffer
+TYPED_TEST (AudioSpectralBufferTests, CopyFromSameBufferNonOverlapping)
+{
+    using BufferType = typename TestFixture::BufferType;
+
+    BufferType buffer (2, 16);
+    this->fillChannel (buffer, 0, TypeParam (10), TypeParam (20));
+
+    buffer.copyFrom (1, 0, buffer, 0, 0, 8);
+
+    const auto* ch0 = buffer.getReadPointer (0);
+    const auto* ch1 = buffer.getReadPointer (1);
+
+    for (int i = 0; i < 16; ++i)
+        EXPECT_EQ (ch1[i], ch0[i]);
+}

--- a/tests/yup_audio_graph/yup_AudioGraphProcessor.cpp
+++ b/tests/yup_audio_graph/yup_AudioGraphProcessor.cpp
@@ -60,10 +60,10 @@ public:
     {
     }
 
-    void prepareToPlay (float sampleRate, int maxBlockSize) override
+    void prepareToPlay (const AudioSpec& spec) override
     {
-        preparedSampleRate = sampleRate;
-        preparedBlockSize = maxBlockSize;
+        preparedSampleRate = spec.sampleRate;
+        preparedBlockSize = spec.maxBlockSize;
         prepared = true;
     }
 
@@ -112,7 +112,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -151,7 +151,7 @@ public:
         nextPendingMidi.ensureSize (4096);
     }
 
-    void prepareToPlay (float, int) override
+    void prepareToPlay (const AudioSpec&) override
     {
         pendingMidi.clear();
         nextPendingMidi.clear();
@@ -245,7 +245,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -365,7 +365,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -444,7 +444,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -524,7 +524,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -577,7 +577,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -748,7 +748,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -798,7 +798,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -843,7 +843,7 @@ public:
         history.clear();
     }
 
-    void prepareToPlay (float, int) override
+    void prepareToPlay (const AudioSpec&) override
     {
         history.clear();
         writePosition = 0;
@@ -912,7 +912,7 @@ TEST (AudioGraphProcessorTests, CommitPreparesNodes)
 
     EXPECT_TRUE (node.isValid());
 
-    graph.prepareToPlay (48000.0f, 128);
+    graph.prepareToPlay (AudioSpec (48000.0f, 128));
     const auto result = graph.commitChanges();
 
     EXPECT_TRUE (result.wasOk());
@@ -978,7 +978,7 @@ TEST (AudioGraphProcessorTests, ProcessesBlocksLargerThanPreparedMaximumInChunks
 {
     auto model = std::make_shared<AudioGraphModel>();
     AudioGraphProcessor graph (model);
-    graph.prepareToPlay (48000.0f, 16);
+    graph.prepareToPlay (AudioSpec (48000.0f, 16));
 
     const auto node = model->addNode (std::make_unique<TestProcessor> (0.5f));
     EXPECT_TRUE (model->addConnection ({ AudioGraphEndpoint::graphInput (0), AudioGraphEndpoint::nodeInput (node, 0) }).wasOk());
@@ -1006,7 +1006,7 @@ TEST (AudioGraphProcessorTests, PreservesMidiEventsInBlocksLargerThanPreparedMax
 {
     auto model = std::make_shared<AudioGraphModel>();
     AudioGraphProcessor graph (model, midiLayout());
-    graph.prepareToPlay (48000.0f, 16);
+    graph.prepareToPlay (AudioSpec (48000.0f, 16));
 
     EXPECT_TRUE (model->addConnection ({ AudioGraphEndpoint::graphInput (0),
                                          AudioGraphEndpoint::graphOutput (0) })
@@ -2128,7 +2128,7 @@ TEST (AudioGraphProcessorTests, ReleaseResourcesMarksPreparedNodesUnprepared)
     const auto node = model->addNode (std::move (processor));
 
     EXPECT_TRUE (node.isValid());
-    graph.prepareToPlay (44100.0f, 64);
+    graph.prepareToPlay (AudioSpec (44100.0f, 64));
     EXPECT_TRUE (processorPtr->prepared);
 
     graph.releaseResources();
@@ -2370,7 +2370,7 @@ TEST (AudioGraphProcessorTests, ConcurrentCommitsDoNotInvalidateAudioThreadPlan)
     auto model = std::make_shared<AudioGraphModel>();
     AudioGraphProcessor graph (model);
     graph.setNumWorkerThreads (2);
-    graph.prepareToPlay (48000.0f, 32);
+    graph.prepareToPlay (AudioSpec (48000.0f, 32));
 
     ASSERT_TRUE (resetGraphToSingleGainPath (graph, 0.25f));
 

--- a/tests/yup_audio_gui/yup_AudioGraphComponent.cpp
+++ b/tests/yup_audio_gui/yup_AudioGraphComponent.cpp
@@ -67,7 +67,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -100,7 +100,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 

--- a/tests/yup_audio_plugin_host/yup_AudioPluginInstance.cpp
+++ b/tests/yup_audio_plugin_host/yup_AudioPluginInstance.cpp
@@ -18,7 +18,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override { prepared = true; }
+    void prepareToPlay (const AudioSpec&) override { prepared = true; }
 
     void releaseResources() override { prepared = false; }
 
@@ -88,7 +88,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -130,7 +130,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 
@@ -212,7 +212,7 @@ TEST_F (AudioPluginInstanceTests, PrepareToPlaySetsPreparedFlag)
 
 TEST_F (AudioPluginInstanceTests, ReleaseResourcesClearsPreparedFlag)
 {
-    instance.prepareToPlay (44100.0f, 512);
+    instance.prepareToPlay (AudioSpec (44100.0f, 512));
     instance.releaseResources();
     EXPECT_FALSE (instance.prepared);
 }
@@ -223,7 +223,7 @@ TEST_F (AudioPluginInstanceTests, ProcessBlockIncrementsCounter)
     MidiBuffer midi;
     ParameterChangeBuffer params;
 
-    instance.prepareToPlay (44100.0f, 512);
+    instance.prepareToPlay (AudioSpec (44100.0f, 512));
     AudioProcessContext<float> ctx { audio, midi, params };
     instance.processBlock (ctx);
 
@@ -269,7 +269,7 @@ TEST_F (AudioPluginInstanceTests, DoublePrecisionProcessBlockUsesDoublePath)
     audio.setSample (0, 0, 1.0);
 
     doublePrecisionInstance.setProcessingPrecision (AudioProcessor::ProcessingPrecision::doublePrecision);
-    doublePrecisionInstance.prepareToPlay (44100.0f, 512);
+    doublePrecisionInstance.prepareToPlay (AudioSpec (44100.0f, 512));
     AudioProcessContext<double> ctx { audio, midi, params };
     doublePrecisionInstance.processBlock (ctx);
 

--- a/tests/yup_audio_plugin_host/yup_AudioPluginState.cpp
+++ b/tests/yup_audio_plugin_host/yup_AudioPluginState.cpp
@@ -16,7 +16,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 

--- a/tests/yup_audio_processors.cpp
+++ b/tests/yup_audio_processors.cpp
@@ -22,3 +22,4 @@
 #include "yup_audio_processors/yup_AudioParameter.cpp"
 #include "yup_audio_processors/yup_AudioProcessContext.cpp"
 #include "yup_audio_processors/yup_ParameterChangeBuffer.cpp"
+#include "yup_audio_processors/yup_SpectralBridge.cpp"

--- a/tests/yup_audio_processors/yup_AudioParameter.cpp
+++ b/tests/yup_audio_processors/yup_AudioParameter.cpp
@@ -36,11 +36,11 @@ public:
     {
     }
 
-    void prepareToPlay (float newSampleRate, int newSamplesPerBlock) override
+    void prepareToPlay (const AudioSpec& spec) override
     {
         ++prepareCallCount;
-        preparedSampleRate = newSampleRate;
-        preparedSamplesPerBlock = newSamplesPerBlock;
+        preparedSampleRate = spec.sampleRate;
+        preparedSamplesPerBlock = spec.maxBlockSize;
     }
 
     void releaseResources() override
@@ -109,10 +109,10 @@ public:
 class ProcessorListener final : public AudioProcessor::Listener
 {
 public:
-    void audioProcessorChanged (AudioProcessor* processor, const AudioProcessor::ChangeDetails& details) override
+    void audioProcessorChanged (AudioProcessorBase* processor, const AudioProcessor::ChangeDetails& details) override
     {
         ++changedCount;
-        lastProcessor = processor;
+        lastProcessor = dynamic_cast<AudioProcessor*> (processor);
         lastDetails = details;
     }
 
@@ -129,7 +129,7 @@ public:
     {
     }
 
-    void prepareToPlay (float, int) override {}
+    void prepareToPlay (const AudioSpec&) override {}
 
     void releaseResources() override {}
 

--- a/tests/yup_audio_processors/yup_SpectralBridge.cpp
+++ b/tests/yup_audio_processors/yup_SpectralBridge.cpp
@@ -1,0 +1,454 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include <gtest/gtest.h>
+
+#include <yup_audio_processors/yup_audio_processors.h>
+
+using namespace yup;
+
+namespace
+{
+
+//==============================================================================
+/** A minimal passthrough SpectralProcessor that does nothing in the frequency domain. */
+class PassthroughSpectralProcessor final : public SpectralProcessor
+{
+public:
+    PassthroughSpectralProcessor()
+        : SpectralProcessor ("Passthrough",
+                             AudioBusLayout ({ AudioBus ("Main", AudioBus::Audio, AudioBus::Input, 2) },
+                                             { AudioBus ("Main", AudioBus::Audio, AudioBus::Output, 2) }))
+    {
+    }
+
+    void prepareToPlay (const SpectralSpec&) override
+    {
+        prepareCalled = true;
+    }
+
+    void releaseResources() override
+    {
+        releaseCalled = true;
+    }
+
+    void processBlock (SpectralProcessContext<float>& context) override
+    {
+        ignoreUnused (context);
+        ++processCount;
+    }
+
+    int getCurrentPreset() const noexcept override { return 0; }
+
+    void setCurrentPreset (int) noexcept override {}
+
+    int getNumPresets() const override { return 0; }
+
+    String getPresetName (int) const override { return {}; }
+
+    void setPresetName (int, StringRef) override {}
+
+    bool prepareCalled = false;
+    bool releaseCalled = false;
+    int processCount = 0;
+};
+
+//==============================================================================
+/** A minimal AudioBusLayout for stereo in/out. */
+AudioBusLayout stereoLayout()
+{
+    return AudioBusLayout ({ AudioBus ("Main", AudioBus::Audio, AudioBus::Input, 2) },
+                           { AudioBus ("Main", AudioBus::Audio, AudioBus::Output, 2) });
+}
+
+} // namespace
+
+//==============================================================================
+class SpectralBridgeTests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        bridge = std::make_unique<SpectralBridge> ("TestBridge", stereoLayout());
+    }
+
+    void TearDown() override
+    {
+        bridge.reset();
+    }
+
+    std::unique_ptr<SpectralBridge> bridge;
+};
+
+//==============================================================================
+TEST_F (SpectralBridgeTests, ConstructsWithDefaultValues)
+{
+    EXPECT_EQ (1024, bridge->getFFTSize());
+    EXPECT_EQ (4, bridge->getOverlapFactor());
+    EXPECT_EQ (1024, bridge->getLatencySamples());
+    EXPECT_EQ (nullptr, bridge->getSpectralProcessor());
+    EXPECT_FALSE (bridge->hasEditor());
+}
+
+TEST_F (SpectralBridgeTests, SetFFTSizeUpdatesLatency)
+{
+    bridge->setFFTSize (2048);
+    EXPECT_EQ (2048, bridge->getFFTSize());
+    EXPECT_EQ (2048, bridge->getLatencySamples());
+}
+
+TEST_F (SpectralBridgeTests, SetFFTSizeIgnoresSameValue)
+{
+    bridge->setFFTSize (1024);
+    EXPECT_EQ (1024, bridge->getFFTSize());
+}
+
+TEST_F (SpectralBridgeTests, SetOverlapFactorUpdatesHopSize)
+{
+    bridge->setOverlapFactor (2);
+    EXPECT_EQ (2, bridge->getOverlapFactor());
+}
+
+TEST_F (SpectralBridgeTests, SetSpectralProcessorRegistersParameters)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+    EXPECT_EQ (proc, bridge->getSpectralProcessor());
+}
+
+TEST_F (SpectralBridgeTests, SetNullSpectralProcessor)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+    bridge->setSpectralProcessor (nullptr);
+    EXPECT_EQ (nullptr, bridge->getSpectralProcessor());
+}
+
+TEST_F (SpectralBridgeTests, PrepareToPlayCallsSpectralProcessorPrepare)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+    bridge->prepareToPlay (AudioSpec (44100.0f, 512, 2));
+    EXPECT_TRUE (proc->prepareCalled);
+}
+
+TEST_F (SpectralBridgeTests, ReleaseResourcesCallsSpectralProcessorRelease)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+    bridge->prepareToPlay (AudioSpec (44100.0f, 512, 2));
+    bridge->releaseResources();
+    EXPECT_TRUE (proc->releaseCalled);
+}
+
+TEST_F (SpectralBridgeTests, FlushCallsSpectralProcessorFlush)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+    bridge->prepareToPlay (AudioSpec (44100.0f, 512, 2));
+    bridge->flush();
+    EXPECT_EQ (0, proc->processCount);
+}
+
+TEST_F (SpectralBridgeTests, ProcessBlockRunsSpectralProcessor)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+    bridge->setFFTSize (128);
+    bridge->prepareToPlay (AudioSpec (44100.0f, 128, 2));
+
+    AudioBuffer<float> audio (2, 128);
+    MidiBuffer midi;
+    ParameterChangeBuffer params;
+
+    audio.clear();
+
+    AudioProcessContext<float> context { audio, midi, params };
+    bridge->processBlock (context);
+
+    EXPECT_GT (proc->processCount, 0);
+}
+
+TEST_F (SpectralBridgeTests, ProcessBlockWithZeroSamplesDoesNothing)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+    bridge->setFFTSize (512);
+    bridge->prepareToPlay (AudioSpec (44100.0f, 128, 2));
+
+    AudioBuffer<float> audio (2, 0);
+    MidiBuffer midi;
+    ParameterChangeBuffer params;
+
+    AudioProcessContext<float> context { audio, midi, params };
+    bridge->processBlock (context);
+
+    EXPECT_EQ (0, proc->processCount);
+}
+
+TEST_F (SpectralBridgeTests, ProcessBlockWithNoSpectralProcessorDoesNothing)
+{
+    bridge->setFFTSize (512);
+    bridge->prepareToPlay (AudioSpec (44100.0f, 128, 2));
+
+    AudioBuffer<float> audio (2, 128);
+    audio.clear();
+
+    MidiBuffer midi;
+    ParameterChangeBuffer params;
+
+    AudioProcessContext<float> context { audio, midi, params };
+    bridge->processBlock (context);
+
+    for (int ch = 0; ch < audio.getNumChannels(); ++ch)
+        for (int s = 0; s < audio.getNumSamples(); ++s)
+            EXPECT_FLOAT_EQ (0.0f, audio.getSample (ch, s));
+}
+
+TEST_F (SpectralBridgeTests, NameIsPreserved)
+{
+    EXPECT_EQ (String ("TestBridge"), bridge->getName());
+}
+
+TEST_F (SpectralBridgeTests, SupportsDataTreeState)
+{
+    EXPECT_TRUE (bridge->supportsDataTreeState());
+}
+
+TEST_F (SpectralBridgeTests, LoadAndSaveStateReturnOk)
+{
+    DataTree tree;
+    EXPECT_TRUE (bridge->loadStateFromDataTree (tree).wasOk());
+    EXPECT_TRUE (bridge->saveStateIntoDataTree (tree).wasOk());
+}
+
+TEST_F (SpectralBridgeTests, ProcessBlockPassesAudioThrough)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+
+    constexpr int kFftSize = 128;
+    constexpr int kBlockSize = 64;
+    constexpr int kNumChannels = 1;
+    constexpr float kSampleRate = 44100.0f;
+    constexpr int kLatency = kFftSize;
+    constexpr int kTotalBlocks = 50;
+    constexpr float kFrequency = 440.0f;
+
+    bridge->setFFTSize (kFftSize);
+    bridge->prepareToPlay (AudioSpec (kSampleRate, kBlockSize, kNumChannels));
+
+    AudioBuffer<float> audio (kNumChannels, kBlockSize);
+    MidiBuffer midi;
+    ParameterChangeBuffer params;
+
+    const int totalSamples = kTotalBlocks * kBlockSize;
+    std::vector<float> inputHistory (static_cast<size_t> (totalSamples), 0.0f);
+    std::vector<float> outputHistory (static_cast<size_t> (totalSamples), 0.0f);
+
+    for (int block = 0; block < kTotalBlocks; ++block)
+    {
+        audio.clear();
+
+        for (int ch = 0; ch < kNumChannels; ++ch)
+        {
+            auto* writePtr = audio.getWritePointer (ch);
+
+            for (int s = 0; s < kBlockSize; ++s)
+            {
+                const int globalSample = block * kBlockSize + s;
+                const float t = static_cast<float> (globalSample) / kSampleRate;
+                const float value = std::sin (2.0f * MathConstants<float>::pi * kFrequency * t);
+                writePtr[s] = value;
+                inputHistory[static_cast<size_t> (globalSample)] = value;
+            }
+        }
+
+        AudioProcessContext<float> context { audio, midi, params };
+        bridge->processBlock (context);
+
+        for (int ch = 0; ch < kNumChannels; ++ch)
+        {
+            const auto* readPtr = audio.getReadPointer (ch);
+
+            for (int s = 0; s < kBlockSize; ++s)
+            {
+                const int globalSample = block * kBlockSize + s;
+                outputHistory[static_cast<size_t> (globalSample)] = readPtr[s];
+            }
+        }
+    }
+
+    // Only compare in the steady-state region after ramp-up has settled.
+    // Ramp-up extends over ~fftSize samples after first frame output begins.
+    constexpr int kRampUpEnd = kLatency + kFftSize;
+    constexpr int kRampDownStart = totalSamples - kFftSize;
+    constexpr float kTolerance = 0.05f;
+
+    int mismatchCount = 0;
+    int comparedSamples = 0;
+
+    for (int s = kRampUpEnd; s < kRampDownStart; ++s)
+    {
+        const float diff = std::abs (outputHistory[static_cast<size_t> (s)]
+                                     - inputHistory[static_cast<size_t> (s - kLatency)]);
+
+        if (diff > kTolerance)
+            ++mismatchCount;
+
+        ++comparedSamples;
+    }
+
+    // Allow up to 5% of samples to mismatch (floating point edge cases)
+    EXPECT_LT (mismatchCount, comparedSamples / 20);
+}
+
+TEST_F (SpectralBridgeTests, FFTSizeChangeKeepsStereoChannelsAligned)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+
+    constexpr int kInitialFftSize = 128;
+    constexpr int kNewFftSize = 256;
+    constexpr int kBlockSize = 64;
+    constexpr int kNumChannels = 2;
+    constexpr float kSampleRate = 44100.0f;
+    constexpr int kTotalBlocks = 32;
+    constexpr float kFrequency = 440.0f;
+
+    bridge->setFFTSize (kInitialFftSize);
+    bridge->prepareToPlay (AudioSpec (kSampleRate, kBlockSize, kNumChannels));
+
+    AudioBuffer<float> audio (kNumChannels, kBlockSize);
+    MidiBuffer midi;
+    ParameterChangeBuffer params;
+
+    for (int block = 0; block < kTotalBlocks; ++block)
+    {
+        if (block == 8)
+            bridge->setFFTSize (kNewFftSize);
+
+        for (int ch = 0; ch < kNumChannels; ++ch)
+        {
+            auto* writePtr = audio.getWritePointer (ch);
+
+            for (int s = 0; s < kBlockSize; ++s)
+            {
+                const int globalSample = block * kBlockSize + s;
+                const float t = static_cast<float> (globalSample) / kSampleRate;
+                writePtr[s] = std::sin (2.0f * MathConstants<float>::pi * kFrequency * t);
+            }
+        }
+
+        AudioProcessContext<float> context { audio, midi, params };
+        bridge->processBlock (context);
+
+        const auto* left = audio.getReadPointer (0);
+        const auto* right = audio.getReadPointer (1);
+
+        for (int s = 0; s < kBlockSize; ++s)
+            EXPECT_NEAR (left[s], right[s], 1.0e-5f);
+    }
+}
+
+TEST_F (SpectralBridgeTests, PrepareToPlayPreservesSampleRate)
+{
+    bridge->setFFTSize (512);
+    bridge->prepareToPlay (AudioSpec (48000.0f, 256, 2));
+    EXPECT_FLOAT_EQ (48000.0f, bridge->getSampleRate());
+    EXPECT_EQ (256, bridge->getSamplesPerBlock());
+}
+
+TEST_F (SpectralBridgeTests, FlushResetsOutput)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+    bridge->setFFTSize (256);
+    bridge->prepareToPlay (AudioSpec (44100.0f, 64, 2));
+
+    AudioBuffer<float> audio (2, 64);
+    MidiBuffer midi;
+    ParameterChangeBuffer params;
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        auto* writePtr = audio.getWritePointer (ch);
+
+        for (int s = 0; s < 64; ++s)
+            writePtr[s] = 1.0f;
+    }
+
+    AudioProcessContext<float> context { audio, midi, params };
+    bridge->processBlock (context);
+    bridge->flush();
+
+    // After flush, a new block with silence should produce silence (after latency)
+    for (int i = 0; i < 10; ++i)
+    {
+        audio.clear();
+        AudioProcessContext<float> ctx { audio, midi, params };
+        bridge->processBlock (ctx);
+    }
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        auto* readPtr = audio.getReadPointer (ch);
+
+        for (int s = 0; s < 64; ++s)
+            EXPECT_NEAR (0.0f, readPtr[s], 1e-4f);
+    }
+}
+
+TEST_F (SpectralBridgeTests, DoubleOverlapProducesSmootherOutput)
+{
+    auto proc = std::make_shared<PassthroughSpectralProcessor>();
+    bridge->setSpectralProcessor (proc);
+    bridge->setFFTSize (256);
+    bridge->setOverlapFactor (8); // 87.5% overlap
+    bridge->prepareToPlay (AudioSpec (44100.0f, 64, 2));
+
+    AudioBuffer<float> audio (2, 64);
+    audio.clear();
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        auto* writePtr = audio.getWritePointer (ch);
+
+        for (int s = 0; s < 64; ++s)
+            writePtr[s] = 1.0f;
+    }
+
+    MidiBuffer midi;
+    ParameterChangeBuffer params;
+
+    AudioProcessContext<float> context { audio, midi, params };
+    bridge->processBlock (context);
+
+    // Output should not have NaN or inf
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        for (int s = 0; s < 64; ++s)
+        {
+            const float sample = audio.getSample (ch, s);
+            EXPECT_TRUE (std::isfinite (sample));
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new "Spectral Processor" type of audio processor (separated from the Audio Processor but unified at the AudioProcessorBase level) and refactors the audio processor interface to use a unified `AudioSpec` and `SpectralSpec` struct for initialization together with `AudioProcessContext` and `SpectralProcessContext`, improving code consistency and extensibility via a new templated `DomainProcessor<DomainProcessContext, DomainSpecification>`. The changes include the implementation and registration of a new audio graph node for processing a passthrough signal using the `SpectralBridge` class that bridges audio to spectral to audio (which will be the base for future spectral nodes) .

Implements the RFC https://github.com/kunitoki/yup/discussions/101