### PR TITLE
Add more options to shader bundler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [2.0.0] - Unreleased
 
+### Breaking changes
+
+- macOS: OpenGL rendering backend disabled in favor of Metal
+
 ### Graphics
-
-#### macOS
-
-- **breaking change** OpenGL rendering backend disabled on macOS in favor of Metal
 
 #### Rive Runtime Bump
 
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - New `ShaderBundleCompiler` class (`shading/yup_ShaderBundleCompiler.h`): drives `ShaderTranspiler` to compile + transpile multiple stage/language combinations in one call and returns a fully-populated `ShaderBundle`. Accepts a `ShaderBundleCompileRequest` with per-stage `ShaderBundleEntry` items (stage, target languages, `TranspileOptions`).
 - New `BinaryOutputArchive` / `BinaryInputArchive` pair (`yup_core/serialisation/yup_BinaryArchive.h`): binary stream archives that plug into the `SerialisationTraits` system; used internally by `ShaderBundle` to serialise `ShaderReflection` data into `REFL` RIFF chunks.
 - New standalone `yup_shader_bundler` console tool (`cmake/tools/shader_bundler`): takes a `.vert` and `.frag` GLSL (v450 Vulkan dialect) pair on disk and produces a single `.ysl` bundle containing transpiled variants for all target languages (GLSL/ESSL/HLSL/MSL).
-- New `yup_add_shader_bundle()` CMake helper (`cmake/yup_shader_bundler.cmake`): builds the `yup_shader_bundler` tool for the host once (cached in the global property `YUP_SHADER_BUNDLER_EXECUTABLE`), runs it at configure time to generate the `.ysl`, and embeds it into a linkable object library via `yup_add_embedded_binary_resources`. Works even when the outer build is cross-compiling, since the tool is built in its own host binary tree without forwarding the cross toolchain.
+- New `yup_add_shader_bundle()` CMake helper (`cmake/yup_shader_bundler.cmake`): builds the `yup_shader_bundler` tool for the host once (cached in the global property `YUP_SHADER_BUNDLER_EXECUTABLE`), runs it at configure time to generate the `.ysl`, and embeds it into a linkable object library via `yup_add_embedded_binary_resources`. Works even when the outer build is cross-compiling, since the tool is built in its own host binary tree without forwarding the cross toolchain. Accepts an `OPTIONS` argument that forwards arbitrary extra flags verbatim to `yup_shader_bundler` (e.g. `--spirv-opt`, `--target-langs`, `-DNAME=VALUE`, `-I<dir>`).
 
 ### Examples
 

--- a/cmake/tools/shader_bundler/source/main.cpp
+++ b/cmake/tools/shader_bundler/source/main.cpp
@@ -72,6 +72,20 @@ static StringArray getAllOptionValues (const ArgumentList& args, StringRef optio
     return values;
 }
 
+// Collects the remainder of every argument that starts with the given prefix,
+// e.g. prefix "-D" over "-DFOO=1" yields "FOO=1" (used for -D and -I flags).
+static StringArray getPrefixedValues (const ArgumentList& args, const String& prefix)
+{
+    StringArray values;
+    for (int i = 0; i < args.size(); ++i)
+    {
+        const String& text = args[i].text;
+        if (text.startsWith (prefix) && text.length() > prefix.length())
+            values.add (text.substring (prefix.length()));
+    }
+    return values;
+}
+
 //==============================================================================
 static String languageToString (ShaderLanguage lang)
 {
@@ -181,31 +195,61 @@ static void printUsage()
         "Usage: yup_shader_bundler [options]\n"
         "\n"
         "Compile mode:\n"
-        "  --vert <path>         Path to vertex shader (.vert) file\n"
-        "  --frag <path>         Path to fragment shader (.frag) file\n"
-        "  --output <path>       Output .ysl bundle file path\n"
-        "  --entry <name>        Shader entry point name (default: main)\n"
-        "  --glsl-version <n>    GLSL version to target (default: 450)\n"
+        "  --stage <stage> <path>  Pipeline stage and source file (repeatable)\n"
+        "                          Stages: vertex, fragment, compute, geometry,\n"
+        "                          tesscontrol, tesseval\n"
+        "  --vert <path>           Shorthand for --stage vertex <path>\n"
+        "  --frag <path>           Shorthand for --stage fragment <path>\n"
+        "  --output <path>         Output .ysl bundle file path\n"
+        "\n"
+        "Source options:\n"
+        "  --source-lang <lang>    Source language: glsl, hlsl, essl (default: glsl)\n"
+        "  --target-langs <list>   Comma-separated target languages\n"
+        "                          (default: glsl,essl,hlsl,msl)\n"
+        "  --entry <name>          Entry point name (default: main)\n"
+        "\n"
+        "Compilation options:\n"
+        "  --glsl-version <n>      GLSL version (default: 450)\n"
+        "  --es                    Emit OpenGL ES-style GLSL\n"
+        "  --hlsl-model <n>        HLSL shader model (e.g. 50, 60; default: 50)\n"
+        "  -DNAME[=VALUE]          Preprocessor define (repeatable)\n"
+        "  -I<dir>                 Include search directory (repeatable)\n"
+        "\n"
+        "SPIR-V options:\n"
+        "  --spirv-opt <mode>      Optimization: none, size, perf (default: none)\n"
+        "  --spirv-validate        Run SPIR-V validation after compilation\n"
+        "  --spirv-debug           Emit debug info in SPIR-V binary\n"
+        "\n"
+        "MSL options:\n"
+        "  --msl-fbfetch           Enable framebuffer fetch for subpass inputs\n"
+        "  --flip-vert-y           Flip vertex Y coordinate\n"
         "\n"
         "Inspect mode:\n"
-        "  --inspect <path>      Inspect an existing .ysl bundle file\n"
-        "  --print <lang>        Print shader source for the given language\n"
-        "                        (glsl, essl, hlsl, msl, spirv, wgsl, all)\n"
-        "                        Can be repeated to print multiple languages\n"
-        "  --stage <stage>       Filter by pipeline stage (vertex, fragment,\n"
-        "                        compute, geometry, tesscontrol, tesseval, all)\n"
-        "                        Can be repeated. Default: all stages\n"
-        "  --list                List all variants with source lengths\n"
-        "  --info                Print reflection data for matched variants\n"
+        "  --inspect <path>        Inspect an existing .ysl bundle file\n"
+        "  --print <lang>          Print shader source for the given language\n"
+        "                          (glsl, essl, hlsl, msl, spirv, wgsl, all)\n"
+        "                          Can be repeated to print multiple languages\n"
+        "  --stage <stage>         Filter by pipeline stage (vertex, fragment,\n"
+        "                          compute, geometry, tesscontrol, tesseval, all)\n"
+        "                          Can be repeated. Default: all stages\n"
+        "  --list                  List all variants with source lengths\n"
+        "  --info                  Print reflection data for matched variants\n"
         "\n"
-        "  --help|-h             Print this help\n");
+        "  --help|-h               Print this help\n");
+}
+
+//==============================================================================
+static std::optional<SpvOptimizationMode> spirvOptFromString (const String& str)
+{
+    if (str.equalsIgnoreCase ("none")) return SpvOptimizationMode::none;
+    if (str.equalsIgnoreCase ("size")) return SpvOptimizationMode::size;
+    if (str.equalsIgnoreCase ("perf")) return SpvOptimizationMode::performance;
+    return {};
 }
 
 //==============================================================================
 static int runCompileMode (const ArgumentList& args)
 {
-    args.failIfOptionIsMissing ("--vert");
-    args.failIfOptionIsMissing ("--frag");
     args.failIfOptionIsMissing ("--output");
 
     const auto resolveFile = [] (const String& path) -> File
@@ -217,112 +261,163 @@ static int runCompileMode (const ArgumentList& args)
         return File::getCurrentWorkingDirectory().getChildFile (path);
     };
 
-    const auto vertPath = resolveFile (getOptionValue (args, "--vert"));
-    const auto fragPath = resolveFile (getOptionValue (args, "--frag"));
+    Logger* log = Logger::getCurrentLogger();
+
+    // -- Collect the requested pipeline stages
+    std::vector<std::pair<ShaderStage, File>> stages;
+
+    if (args.containsOption ("--vert"))
+        stages.emplace_back (ShaderStage::vertex, resolveFile (getOptionValue (args, "--vert")));
+
+    if (args.containsOption ("--frag"))
+        stages.emplace_back (ShaderStage::fragment, resolveFile (getOptionValue (args, "--frag")));
+
+    // General form: --stage <stage> <path>
+    for (int i = 0; i < args.size(); ++i)
+    {
+        if (args[i] == "--stage" && i + 2 < args.size()
+            && ! args[i + 1].isOption() && ! args[i + 2].isOption())
+        {
+            auto st = stageFromString (args[i + 1].text);
+            if (st.has_value())
+                stages.emplace_back (*st, resolveFile (args[i + 2].text));
+            else
+                log->writeToLog ("Warning: unknown stage '" + args[i + 1].text + "', skipping.");
+
+            i += 2;
+        }
+    }
+
+    if (stages.empty())
+    {
+        log->writeToLog ("No shader stages specified. Use --vert, --frag, or --stage <stage> <path>.");
+        return 1;
+    }
+
     const auto outputPath = resolveFile (getOptionValue (args, "--output"));
 
-    const auto entryPoint = getOptionValue (args, "--entry", "main");
-
-    const String glslVersionVal = getOptionValue (args, "--glsl-version", "450");
-    const int glslVersion = glslVersionVal.getIntValue();
-
-    // -- Validate input files
-    if (! vertPath.existsAsFile())
+    // -- Source language
+    ShaderLanguage sourceLanguage = ShaderLanguage::glsl;
+    if (args.containsOption ("--source-lang"))
     {
-        const String msg = "Vertex shader file not found: " + vertPath.getFullPathName();
-        Logger::getCurrentLogger()->writeToLog (msg);
-        return 1;
+        const String slVal = getOptionValue (args, "--source-lang");
+        auto sl = languageFromString (slVal);
+        if (! sl.has_value())
+        {
+            log->writeToLog ("Unknown source language: " + slVal);
+            return 1;
+        }
+        sourceLanguage = *sl;
     }
 
-    if (! fragPath.existsAsFile())
+    // -- Target languages
+    std::vector<ShaderLanguage> targetLanguages;
+    if (args.containsOption ("--target-langs"))
     {
-        const String msg = "Fragment shader file not found: " + fragPath.getFullPathName();
-        Logger::getCurrentLogger()->writeToLog (msg);
-        return 1;
+        const StringArray parts = StringArray::fromTokens (getOptionValue (args, "--target-langs"), ",", "");
+        for (const auto& p : parts)
+        {
+            const String trimmed = p.trim();
+            if (trimmed.isEmpty())
+                continue;
+
+            auto tl = languageFromString (trimmed);
+            if (tl.has_value())
+                targetLanguages.push_back (*tl);
+            else
+                log->writeToLog ("Warning: unknown target language '" + trimmed + "', skipping.");
+        }
     }
 
-    const String vertSource = vertPath.loadFileAsString();
-    const String fragSource = fragPath.loadFileAsString();
+    if (targetLanguages.empty())
+        targetLanguages = { ShaderLanguage::glsl, ShaderLanguage::essl, ShaderLanguage::hlsl, ShaderLanguage::msl };
 
-    if (vertSource.isEmpty())
+    // -- Shared transpile options
+    TranspileOptions options;
+    options.entryPoint = getOptionValue (args, "--entry", "main");
+    options.glslVersion = getOptionValue (args, "--glsl-version", "450").getIntValue();
+    options.es = args.containsOption ("--es");
+    options.mslUsesFramebufferFetch = args.containsOption ("--msl-fbfetch");
+    options.flipVertY = args.containsOption ("--flip-vert-y");
+    options.spirvValidate = args.containsOption ("--spirv-validate");
+    options.spirvDebugInfo = args.containsOption ("--spirv-debug");
+
+    if (args.containsOption ("--hlsl-model"))
+        options.hlslShaderModel = getOptionValue (args, "--hlsl-model").getIntValue();
+
+    if (args.containsOption ("--spirv-opt"))
     {
-        const String msg = "Vertex shader file is empty: " + vertPath.getFullPathName();
-        Logger::getCurrentLogger()->writeToLog (msg);
-        return 1;
+        const String optVal = getOptionValue (args, "--spirv-opt");
+        auto mode = spirvOptFromString (optVal);
+        if (! mode.has_value())
+        {
+            log->writeToLog ("Unknown SPIR-V optimization mode: " + optVal);
+            return 1;
+        }
+        options.spirvOptimization = *mode;
     }
 
-    if (fragSource.isEmpty())
+    for (const auto& d : getPrefixedValues (args, "-D"))
     {
-        const String msg = "Fragment shader file is empty: " + fragPath.getFullPathName();
-        Logger::getCurrentLogger()->writeToLog (msg);
-        return 1;
+        const int eq = d.indexOfChar ('=');
+        if (eq >= 0)
+            options.defines.set (d.substring (0, eq), d.substring (eq + 1));
+        else
+            options.defines.set (d, {});
     }
 
-    // -- Target all supported shading languages
-    const std::vector<ShaderLanguage> targetLanguages = {
-        ShaderLanguage::glsl,
-        ShaderLanguage::essl,
-        ShaderLanguage::hlsl,
-        ShaderLanguage::msl
-    };
+    for (const auto& inc : getPrefixedValues (args, "-I"))
+        options.includePaths.push_back (resolveFile (inc).getFullPathName());
 
-    auto makeEntry = [&] (ShaderStage stage)
+    // -- Compile every stage and merge into a single bundle
+    ShaderBundleCompiler compiler;
+    ShaderBundle bundle;
+
+    for (const auto& [stage, path] : stages)
     {
+        if (! path.existsAsFile())
+        {
+            log->writeToLog (stageToString (stage) + " shader file not found: " + path.getFullPathName());
+            return 1;
+        }
+
+        const String source = path.loadFileAsString();
+        if (source.isEmpty())
+        {
+            log->writeToLog (stageToString (stage) + " shader file is empty: " + path.getFullPathName());
+            return 1;
+        }
+
         ShaderBundleEntry entry;
         entry.stage = stage;
         entry.targetLanguages = targetLanguages;
-        entry.options.entryPoint = entryPoint;
-        entry.options.glslVersion = glslVersion;
-        return entry;
-    };
+        entry.options = options;
 
-    ShaderBundleCompiler compiler;
+        ShaderBundleCompileRequest request;
+        request.source = source;
+        request.sourceLanguage = sourceLanguage;
+        request.entries.push_back (entry);
 
-    // Compile vertex stage
-    ShaderBundleCompileRequest vertRequest;
-    vertRequest.source = vertSource;
-    vertRequest.sourceLanguage = ShaderLanguage::glsl;
-    vertRequest.entries.push_back (makeEntry (ShaderStage::vertex));
+        auto result = compiler.compile (request);
+        if (result.failed())
+        {
+            log->writeToLog (stageToString (stage) + " shader compilation failed: " + result.getErrorMessage());
+            return 1;
+        }
 
-    auto vsBundle = compiler.compile (vertRequest);
-    if (vsBundle.failed())
-    {
-        const String msg = "Vertex shader compilation failed: " + vsBundle.getErrorMessage();
-        Logger::getCurrentLogger()->writeToLog (msg);
-        return 1;
+        for (const auto& info : result.getReference().getShaders())
+            bundle.addShader (info);
     }
-
-    // Compile fragment stage
-    ShaderBundleCompileRequest fragRequest;
-    fragRequest.source = fragSource;
-    fragRequest.sourceLanguage = ShaderLanguage::glsl;
-    fragRequest.entries.push_back (makeEntry (ShaderStage::fragment));
-
-    auto fsBundle = compiler.compile (fragRequest);
-    if (fsBundle.failed())
-    {
-        const String msg = "Fragment shader compilation failed: " + fsBundle.getErrorMessage();
-        Logger::getCurrentLogger()->writeToLog (msg);
-        return 1;
-    }
-
-    // Merge both stages into a single bundle
-    ShaderBundle bundle;
-    for (const auto& info : vsBundle.getReference().getShaders())
-        bundle.addShader (info);
-    for (const auto& info : fsBundle.getReference().getShaders())
-        bundle.addShader (info);
 
     // Persist to file
     const auto saveResult = bundle.saveToFile (outputPath);
     if (saveResult.failed())
     {
-        const String msg = "Failed to save bundle: " + saveResult.getErrorMessage();
-        Logger::getCurrentLogger()->writeToLog (msg);
+        log->writeToLog ("Failed to save bundle: " + saveResult.getErrorMessage());
         return 1;
     }
 
-    Logger::getCurrentLogger()->writeToLog ("Shader bundle written to: " + outputPath.getFullPathName());
+    log->writeToLog ("Shader bundle written to: " + outputPath.getFullPathName());
     return 0;
 }
 
@@ -506,7 +601,8 @@ int main (int argc, char* argv[])
     if (args.containsOption ("--inspect"))
         return runInspectMode (args);
 
-    if (args.containsOption ("--vert") || args.containsOption ("--frag") || args.containsOption ("--output"))
+    if (args.containsOption ("--vert") || args.containsOption ("--frag")
+        || args.containsOption ("--stage") || args.containsOption ("--output"))
         return runCompileMode (args);
 
     printUsage();

--- a/cmake/yup_shader_bundler.cmake
+++ b/cmake/yup_shader_bundler.cmake
@@ -82,13 +82,17 @@ endfunction()
 #
 # Usage:
 #   yup_add_shader_bundle (<library_name>
-#       VERT          <path to .vert file>
-#       FRAG          <path to .frag file>
-#       [OUTPUT_NAME  <basename>]      # default: <library_name>
-#       [RESOURCE_NAME <symbol>]       # default: <library_name>
-#       [NAMESPACE    <namespace>]     # default: yup
-#       [ENTRY        <entry point>]   # default: main
-#       [GLSL_VERSION <version>])      # default: 450
+#       VERT           <path to .vert file>
+#       FRAG           <path to .frag file>
+#       [OUTPUT_NAME   <basename>]      # default: <library_name>
+#       [RESOURCE_NAME <symbol>]        # default: <library_name>
+#       [NAMESPACE     <namespace>]     # default: yup
+#       [ENTRY         <entry point>]   # default: main
+#       [GLSL_VERSION  <version>]       # default: 450
+#       [OPTIONS       <flag>...])      # extra flags forwarded to yup_shader_bundler
+#
+# OPTIONS forwards any additional yup_shader_bundler flags verbatim, e.g.
+#   OPTIONS --spirv-opt perf --target-langs msl,hlsl -DMY_DEFINE=1 -I${CMAKE_SOURCE_DIR}/shaders
 #
 # After the call, link against <library_name> and include the generated header
 # "<OUTPUT_NAME>.h", which exposes:
@@ -99,7 +103,7 @@ endfunction()
 function (yup_add_shader_bundle library_name)
     set (options "")
     set (one_value_args VERT FRAG OUTPUT_NAME RESOURCE_NAME NAMESPACE ENTRY GLSL_VERSION)
-    set (multi_value_args "")
+    set (multi_value_args OPTIONS)
 
     cmake_parse_arguments (YUP_ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
 
@@ -139,7 +143,8 @@ function (yup_add_shader_bundle library_name)
             --frag "${frag_path}"
             --output "${bundle_path}"
             --entry "${YUP_ARG_ENTRY}"
-            --glsl-version "${YUP_ARG_GLSL_VERSION}")
+            --glsl-version "${YUP_ARG_GLSL_VERSION}"
+            ${YUP_ARG_OPTIONS})
 
     # ==== Embed the generated bundle into an object library
     yup_add_embedded_binary_resources (

--- a/modules/yup_graphics/rhi/yup_GpuPipeline.cpp
+++ b/modules/yup_graphics/rhi/yup_GpuPipeline.cpp
@@ -752,7 +752,7 @@ ResultValue<GpuPipeline::Ptr> GpuPipeline::compileFromGlsl (GraphicsContext& ctx
         ShaderBundleEntry entry;
         entry.stage = stage;
         entry.targetLanguages = { targetLang };
-        entry.options.spirvOptimize = false;
+        entry.options.spirvOptimization = SpvOptimizationMode::none;
         return entry;
     };
 

--- a/modules/yup_shading/shading/yup_ShaderTranspiler.cpp
+++ b/modules/yup_shading/shading/yup_ShaderTranspiler.cpp
@@ -1053,7 +1053,25 @@ ResultValue<MemoryBlock> ShaderTranspiler::compileToSPIRV (const String& source,
 
     int defaultVersion = (sourceLang == ShaderLanguage::essl) ? 300 : 100;
 
-    if (! shader.parse (&resources, defaultVersion, false, messages))
+    if (! options.includePaths.empty())
+    {
+        DirStackFileIncluder includer;
+
+        for (const auto& path : options.includePaths)
+            includer.pushExternalDirectory (path.toStdString());
+
+        if (! shader.parse (&resources, defaultVersion, false, messages, includer))
+        {
+            String infoLog = shader.getInfoLog();
+            String debugLog = shader.getInfoDebugLog();
+
+            if (infoLog.isEmpty() && debugLog.isNotEmpty())
+                return makeResultValueFail (debugLog);
+
+            return makeResultValueFail (infoLog);
+        }
+    }
+    else if (! shader.parse (&resources, defaultVersion, false, messages))
     {
         String infoLog = shader.getInfoLog();
         String debugLog = shader.getInfoDebugLog();
@@ -1080,8 +1098,26 @@ ResultValue<MemoryBlock> ShaderTranspiler::compileToSPIRV (const String& source,
 
     std::vector<uint32_t> spirv;
     glslang::SpvOptions spvOptions;
-    spvOptions.disableOptimizer = ! options.spirvOptimize;
-    spvOptions.optimizeSize = options.spirvOptimize;
+
+    switch (options.spirvOptimization)
+    {
+        case SpvOptimizationMode::none:
+            spvOptions.disableOptimizer = true;
+            spvOptions.optimizeSize = false;
+            break;
+        case SpvOptimizationMode::size:
+            spvOptions.disableOptimizer = false;
+            spvOptions.optimizeSize = true;
+            break;
+        case SpvOptimizationMode::performance:
+            spvOptions.disableOptimizer = false;
+            spvOptions.optimizeSize = false;
+            break;
+    }
+
+    spvOptions.validate = options.spirvValidate;
+    spvOptions.generateDebugInfo = options.spirvDebugInfo;
+
     glslang::GlslangToSpv (*program.getIntermediate (glslStage), spirv, &spvOptions);
 
     if (spirv.empty())

--- a/modules/yup_shading/shading/yup_ShaderTranspiler.h
+++ b/modules/yup_shading/shading/yup_ShaderTranspiler.h
@@ -25,6 +25,15 @@ namespace yup
 {
 
 //==============================================================================
+/** SPIR-V optimization mode applied during compilation. */
+enum class SpvOptimizationMode
+{
+    none,       /**< No optimization (glslang optimizer disabled). */
+    size,       /**< Optimize the generated SPIR-V for size. */
+    performance /**< Optimize the generated SPIR-V for performance. */
+};
+
+//==============================================================================
 /** Options controlling transpilation behavior. */
 struct TranspileOptions
 {
@@ -46,11 +55,20 @@ struct TranspileOptions
     /** When true, flip the Y coordinate in vertex output (MSL). */
     bool flipVertY = false;
 
-    /** Enable SPIR-V optimization (requires SPIRV-Tools linked into glslang). */
-    bool spirvOptimize = false;
+    /** SPIR-V optimization mode (requires SPIRV-Tools linked into glslang). */
+    SpvOptimizationMode spirvOptimization = SpvOptimizationMode::none;
+
+    /** When true, run SPIR-V validation after compilation. */
+    bool spirvValidate = false;
+
+    /** When true, emit debug info into the SPIR-V binary. */
+    bool spirvDebugInfo = false;
 
     /** Preprocessor defines (name → value, empty string for no-value defines). */
     HashMap<String, String> defines;
+
+    /** Include search paths for resolving #include directives (-I&lt;dir&gt; style). */
+    std::vector<String> includePaths;
 
     //==========================================================================
     /**
@@ -68,7 +86,16 @@ struct TranspileOptions
                 << "|hlslSM:" << hlslShaderModel
                 << "|mslFBF:" << (mslUsesFramebufferFetch ? '1' : '0')
                 << "|flipY:" << (flipVertY ? '1' : '0')
-                << "|spvOpt:" << (spirvOptimize ? '1' : '0');
+                << "|spvOpt:" << static_cast<int> (spirvOptimization)
+                << "|spvValidate:" << (spirvValidate ? '1' : '0')
+                << "|spvDebug:" << (spirvDebugInfo ? '1' : '0');
+
+        // Include paths sorted for determinism
+        std::vector<String> sortedPaths (includePaths.begin(), includePaths.end());
+        std::sort (sortedPaths.begin(), sortedPaths.end());
+
+        for (const auto& p : sortedPaths)
+            payload << "|inc:" << p;
 
         // Defines sorted for determinism
         std::vector<std::pair<String, String>> sortedDefines;

--- a/modules/yup_shading/yup_shading.cpp
+++ b/modules/yup_shading/yup_shading.cpp
@@ -35,6 +35,7 @@
 
 #if YUP_ENABLE_SHADER_TRANSPILER
 #include <glslang/glslang.h>
+#include <glslang/upstream/StandAlone/DirStackFileIncluder.h>
 #include <spirv_cross/spirv_cross.h>
 
 #include "shading/yup_ShaderTranspiler.cpp"

--- a/tests/yup_shading/yup_ShaderBundle.cpp
+++ b/tests/yup_shading/yup_ShaderBundle.cpp
@@ -899,4 +899,49 @@ TEST_F (ShaderBundleCompilerTests, CompileVertexToESSL)
     EXPECT_NE (info->source, info->inputSource);
 }
 
+TEST_F (ShaderBundleCompilerTests, CompileWithSpirvOptimizationSucceeds)
+{
+    ShaderBundleCompiler compiler (transpiler);
+
+    ShaderBundleCompileRequest req;
+    req.source = kShaderBundleMinimalFragmentGLSL;
+    req.sourceLanguage = ShaderLanguage::glsl;
+
+    ShaderBundleEntry entry;
+    entry.stage = ShaderStage::fragment;
+    entry.targetLanguages = { ShaderLanguage::glsl };
+    entry.options.spirvOptimization = SpvOptimizationMode::performance;
+    req.entries.push_back (entry);
+
+    auto result = compiler.compile (req);
+    ASSERT_TRUE (result.wasOk()) << result.getErrorMessage();
+
+    const auto* info = result.getReference().findShader (ShaderStage::fragment, ShaderLanguage::glsl);
+    ASSERT_NE (info, nullptr);
+    EXPECT_FALSE (info->source.isEmpty());
+}
+
+TEST_F (ShaderBundleCompilerTests, CompileWithSpirvDebugInfoSucceeds)
+{
+    ShaderBundleCompiler compiler (transpiler);
+
+    ShaderBundleCompileRequest req;
+    req.source = kShaderBundleMinimalFragmentGLSL;
+    req.sourceLanguage = ShaderLanguage::glsl;
+
+    ShaderBundleEntry entry;
+    entry.stage = ShaderStage::fragment;
+    entry.targetLanguages = { ShaderLanguage::glsl };
+    entry.options.spirvDebugInfo = true;
+    entry.options.spirvValidate = true;
+    req.entries.push_back (entry);
+
+    auto result = compiler.compile (req);
+    ASSERT_TRUE (result.wasOk()) << result.getErrorMessage();
+
+    const auto* info = result.getReference().findShader (ShaderStage::fragment, ShaderLanguage::glsl);
+    ASSERT_NE (info, nullptr);
+    EXPECT_FALSE (info->source.isEmpty());
+}
+
 #endif // YUP_ENABLE_SHADER_TRANSPILER

--- a/tests/yup_shading/yup_ShaderCache.cpp
+++ b/tests/yup_shading/yup_ShaderCache.cpp
@@ -305,6 +305,81 @@ TEST_F (ShaderCacheTests, GenerateCacheKey_MSLOptionsChangeKey)
     EXPECT_NE (key1, key2);
 }
 
+TEST_F (ShaderCacheTests, GenerateCacheKey_SpirvOptimizationChangesKey)
+{
+    TranspileOptions optsNone;
+    optsNone.spirvOptimization = SpvOptimizationMode::none;
+
+    TranspileOptions optsSize;
+    optsSize.spirvOptimization = SpvOptimizationMode::size;
+
+    TranspileOptions optsPerf;
+    optsPerf.spirvOptimization = SpvOptimizationMode::performance;
+
+    auto keyNone = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, optsNone);
+    auto keySize = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, optsSize);
+    auto keyPerf = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, optsPerf);
+
+    EXPECT_NE (keyNone, keySize);
+    EXPECT_NE (keyNone, keyPerf);
+    EXPECT_NE (keySize, keyPerf);
+}
+
+TEST_F (ShaderCacheTests, GenerateCacheKey_SpirvValidateAndDebugChangeKey)
+{
+    TranspileOptions base;
+
+    TranspileOptions validate;
+    validate.spirvValidate = true;
+
+    TranspileOptions debug;
+    debug.spirvDebugInfo = true;
+
+    auto keyBase = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, base);
+    auto keyValidate = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, validate);
+    auto keyDebug = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, debug);
+
+    EXPECT_NE (keyBase, keyValidate);
+    EXPECT_NE (keyBase, keyDebug);
+}
+
+TEST_F (ShaderCacheTests, GenerateCacheKey_IncludePathsChangeKey)
+{
+    TranspileOptions base;
+
+    TranspileOptions withInc;
+    withInc.includePaths = { "/shaders/common", "/shaders/lib" };
+
+    auto keyBase = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, base);
+    auto keyInc = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, withInc);
+
+    EXPECT_NE (keyBase, keyInc);
+}
+
+TEST_F (ShaderCacheTests, GenerateCacheKey_IncludePathOrderIsDeterministic)
+{
+    TranspileOptions a;
+    a.includePaths = { "/shaders/common", "/shaders/lib" };
+
+    TranspileOptions b;
+    b.includePaths = { "/shaders/lib", "/shaders/common" };
+
+    auto keyA = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, a);
+    auto keyB = ShaderCache::generateCacheKey (
+        kTestVertex, ShaderStage::vertex, ShaderLanguage::glsl, b);
+
+    EXPECT_EQ (keyA, keyB);
+}
+
 //==============================================================================
 // store / contains / remove / clear
 //==============================================================================

--- a/tests/yup_shading/yup_ShaderTranspiler.cpp
+++ b/tests/yup_shading/yup_ShaderTranspiler.cpp
@@ -510,6 +510,43 @@ void main()
 }
 )glsl";
 
+// Shader containing dead code that an optimizer can eliminate. Used to observe
+// SPIR-V size differences between optimization modes.
+constexpr const char* kFragmentWithDeadCode = R"glsl(
+#version 450
+layout(location = 0) out vec4 outColor;
+layout(location = 0) in vec2 vUV;
+void main()
+{
+    float unused0 = vUV.x * 2.0;
+    float unused1 = unused0 + vUV.y;
+    float unused2 = unused1 * unused0 - vUV.x;
+    vec4 unusedVec = vec4(unused2, unused1, unused0, 1.0) * 0.0;
+    outColor = vec4(1.0, 0.0, 0.0, 1.0) + unusedVec * 0.0;
+}
+)glsl";
+
+// Header file body pulled in via a system-style #include (searched through the
+// external -I directories set on TranspileOptions::includePaths).
+constexpr const char* kIncludeHeaderBody = R"glsl(
+vec4 getTestColor()
+{
+    return vec4(1.0, 0.5, 0.25, 1.0);
+}
+)glsl";
+
+// Fragment shader that requires a system #include to be resolvable.
+constexpr const char* kFragmentWithSystemInclude = R"glsl(
+#version 450
+#extension GL_GOOGLE_include_directive : require
+#include <yup_test_include_header.glsl>
+layout(location = 0) out vec4 outColor;
+void main()
+{
+    outColor = getTestColor();
+}
+)glsl";
+
 } // namespace
 
 //==============================================================================
@@ -673,6 +710,168 @@ TEST_F (ShaderTranspilerTests, CompileToSPIRV_TessEvalShader)
 
     ASSERT_TRUE (result.wasOk());
     EXPECT_GT (result.getValue().getSize(), sizeof (uint32_t) * 5u);
+}
+
+//==============================================================================
+// compileToSPIRV — SPIR-V optimization / validation / debug info
+//==============================================================================
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_OptimizationNoneCompiles)
+{
+    TranspileOptions opts;
+    opts.spirvOptimization = SpvOptimizationMode::none;
+
+    auto result = transpiler->compileToSPIRV (
+        kFragmentWithDeadCode, ShaderStage::fragment, ShaderLanguage::glsl, opts);
+
+    ASSERT_TRUE (result.wasOk()) << result.getErrorMessage();
+    EXPECT_GT (result.getValue().getSize(), sizeof (uint32_t) * 5u);
+}
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_OptimizationSizeCompiles)
+{
+    TranspileOptions opts;
+    opts.spirvOptimization = SpvOptimizationMode::size;
+
+    auto result = transpiler->compileToSPIRV (
+        kFragmentWithDeadCode, ShaderStage::fragment, ShaderLanguage::glsl, opts);
+
+    ASSERT_TRUE (result.wasOk()) << result.getErrorMessage();
+    EXPECT_GT (result.getValue().getSize(), sizeof (uint32_t) * 5u);
+}
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_OptimizationPerformanceCompiles)
+{
+    TranspileOptions opts;
+    opts.spirvOptimization = SpvOptimizationMode::performance;
+
+    auto result = transpiler->compileToSPIRV (
+        kFragmentWithDeadCode, ShaderStage::fragment, ShaderLanguage::glsl, opts);
+
+    ASSERT_TRUE (result.wasOk()) << result.getErrorMessage();
+    EXPECT_GT (result.getValue().getSize(), sizeof (uint32_t) * 5u);
+}
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_OptimizationDoesNotGrowDeadCode)
+{
+    TranspileOptions noneOpts;
+    noneOpts.spirvOptimization = SpvOptimizationMode::none;
+
+    TranspileOptions sizeOpts;
+    sizeOpts.spirvOptimization = SpvOptimizationMode::size;
+
+    auto unoptimized = transpiler->compileToSPIRV (
+        kFragmentWithDeadCode, ShaderStage::fragment, ShaderLanguage::glsl, noneOpts);
+    auto optimized = transpiler->compileToSPIRV (
+        kFragmentWithDeadCode, ShaderStage::fragment, ShaderLanguage::glsl, sizeOpts);
+
+    ASSERT_TRUE (unoptimized.wasOk()) << unoptimized.getErrorMessage();
+    ASSERT_TRUE (optimized.wasOk()) << optimized.getErrorMessage();
+
+    // Whether or not the SPIRV-Tools optimizer is linked in, size-optimized
+    // output must never be larger than the unoptimized binary.
+    EXPECT_LE (optimized.getValue().getSize(), unoptimized.getValue().getSize());
+}
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_ValidationPassesForValidShader)
+{
+    TranspileOptions opts;
+    opts.spirvValidate = true;
+
+    auto result = transpiler->compileToSPIRV (
+        kFragmentWithUniforms, ShaderStage::fragment, ShaderLanguage::glsl, opts);
+
+    ASSERT_TRUE (result.wasOk()) << result.getErrorMessage();
+    EXPECT_GT (result.getValue().getSize(), sizeof (uint32_t) * 5u);
+}
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_DebugInfoProducesLargerBinary)
+{
+    TranspileOptions plainOpts;
+
+    TranspileOptions debugOpts;
+    debugOpts.spirvDebugInfo = true;
+
+    auto plain = transpiler->compileToSPIRV (
+        kFragmentWithUniforms, ShaderStage::fragment, ShaderLanguage::glsl, plainOpts);
+    auto debug = transpiler->compileToSPIRV (
+        kFragmentWithUniforms, ShaderStage::fragment, ShaderLanguage::glsl, debugOpts);
+
+    ASSERT_TRUE (plain.wasOk()) << plain.getErrorMessage();
+    ASSERT_TRUE (debug.wasOk()) << debug.getErrorMessage();
+
+    // Debug info adds OpSource / OpName / OpLine entries, growing the binary.
+    EXPECT_GT (debug.getValue().getSize(), plain.getValue().getSize());
+}
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_DebugInfoDecompilesToValidTarget)
+{
+    TranspileOptions opts;
+    opts.spirvDebugInfo = true;
+
+    auto spirv = transpiler->compileToSPIRV (
+        kFragmentWithUniforms, ShaderStage::fragment, ShaderLanguage::glsl, opts);
+    ASSERT_TRUE (spirv.wasOk()) << spirv.getErrorMessage();
+
+    auto decompiled = transpiler->decompileFromSPIRV (
+        spirv.getValue(), ShaderLanguage::msl);
+
+    ASSERT_TRUE (decompiled.wasOk()) << decompiled.getErrorMessage();
+    EXPECT_TRUE (decompiled.getValue().contains ("metal"));
+}
+
+//==============================================================================
+// compileToSPIRV — include paths
+//==============================================================================
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_IncludeFailsWithoutSearchPath)
+{
+    // No include paths set: the default ForbidIncluder must reject the #include.
+    auto result = transpiler->compileToSPIRV (
+        kFragmentWithSystemInclude, ShaderStage::fragment, ShaderLanguage::glsl);
+
+    EXPECT_TRUE (result.failed());
+    EXPECT_TRUE (result.getErrorMessage().isNotEmpty());
+}
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_IncludeResolvesFromSearchPath)
+{
+    const auto includeDir = File::getSpecialLocation (File::tempDirectory)
+                                .getChildFile ("yup_shader_include_test");
+    ASSERT_TRUE (includeDir.createDirectory().wasOk());
+
+    const auto headerFile = includeDir.getChildFile ("yup_test_include_header.glsl");
+    ASSERT_TRUE (headerFile.replaceWithText (kIncludeHeaderBody));
+
+    TranspileOptions opts;
+    opts.includePaths.push_back (includeDir.getFullPathName());
+
+    auto result = transpiler->compileToSPIRV (
+        kFragmentWithSystemInclude, ShaderStage::fragment, ShaderLanguage::glsl, opts);
+
+    headerFile.deleteFile();
+    includeDir.deleteRecursively();
+
+    ASSERT_TRUE (result.wasOk()) << result.getErrorMessage();
+    EXPECT_GT (result.getValue().getSize(), sizeof (uint32_t) * 5u);
+}
+
+TEST_F (ShaderTranspilerTests, CompileToSPIRV_IncludeFailsWhenHeaderMissingInSearchPath)
+{
+    const auto includeDir = File::getSpecialLocation (File::tempDirectory)
+                                .getChildFile ("yup_shader_include_missing_test");
+    ASSERT_TRUE (includeDir.createDirectory().wasOk());
+
+    // Directory exists but does not contain the requested header.
+    TranspileOptions opts;
+    opts.includePaths.push_back (includeDir.getFullPathName());
+
+    auto result = transpiler->compileToSPIRV (
+        kFragmentWithSystemInclude, ShaderStage::fragment, ShaderLanguage::glsl, opts);
+
+    includeDir.deleteRecursively();
+
+    EXPECT_TRUE (result.failed());
 }
 
 //==============================================================================
@@ -2309,4 +2508,164 @@ TEST_F (ShaderTranspilerTests, ReflectFromSPIRV_MSL_StageInputAndOutputSlots)
     {
         EXPECT_EQ (so.backendSlot, ~0u);
     }
+}
+
+//==============================================================================
+// TranspileOptions::toCacheKeyPayload
+//==============================================================================
+
+TEST (TranspileOptionsTests, CacheKeyPayload_DefaultsAreDeterministic)
+{
+    TranspileOptions a;
+    TranspileOptions b;
+
+    EXPECT_EQ (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_EntryPointAffectsKey)
+{
+    TranspileOptions a;
+    a.entryPoint = "main";
+
+    TranspileOptions b;
+    b.entryPoint = "vertexMain";
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_GlslVersionAffectsKey)
+{
+    TranspileOptions a;
+    a.glslVersion = 450;
+
+    TranspileOptions b;
+    b.glslVersion = 330;
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_EsFlagAffectsKey)
+{
+    TranspileOptions a;
+    a.es = false;
+
+    TranspileOptions b;
+    b.es = true;
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_HlslShaderModelAffectsKey)
+{
+    TranspileOptions a;
+    a.hlslShaderModel = 50;
+
+    TranspileOptions b;
+    b.hlslShaderModel = 60;
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_OptimizationModeAffectsKey)
+{
+    TranspileOptions none;
+    none.spirvOptimization = SpvOptimizationMode::none;
+
+    TranspileOptions size;
+    size.spirvOptimization = SpvOptimizationMode::size;
+
+    TranspileOptions perf;
+    perf.spirvOptimization = SpvOptimizationMode::performance;
+
+    EXPECT_NE (none.toCacheKeyPayload(), size.toCacheKeyPayload());
+    EXPECT_NE (none.toCacheKeyPayload(), perf.toCacheKeyPayload());
+    EXPECT_NE (size.toCacheKeyPayload(), perf.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_ValidateFlagAffectsKey)
+{
+    TranspileOptions a;
+
+    TranspileOptions b;
+    b.spirvValidate = true;
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_DebugInfoFlagAffectsKey)
+{
+    TranspileOptions a;
+
+    TranspileOptions b;
+    b.spirvDebugInfo = true;
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_IncludePathsAffectKey)
+{
+    TranspileOptions a;
+
+    TranspileOptions b;
+    b.includePaths.push_back ("/shaders/common");
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_IncludePathOrderIsDeterministic)
+{
+    TranspileOptions a;
+    a.includePaths = { "/shaders/common", "/shaders/lib" };
+
+    TranspileOptions b;
+    b.includePaths = { "/shaders/lib", "/shaders/common" };
+
+    // Include paths are sorted before hashing, so ordering must not matter.
+    EXPECT_EQ (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_DifferentIncludePathsDiffer)
+{
+    TranspileOptions a;
+    a.includePaths = { "/shaders/common" };
+
+    TranspileOptions b;
+    b.includePaths = { "/shaders/other" };
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_DefinesAffectKey)
+{
+    TranspileOptions a;
+
+    TranspileOptions b;
+    b.defines.set ("FOO", "1");
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_DefineOrderIsDeterministic)
+{
+    TranspileOptions a;
+    a.defines.set ("FOO", "1");
+    a.defines.set ("BAR", "2");
+
+    TranspileOptions b;
+    b.defines.set ("BAR", "2");
+    b.defines.set ("FOO", "1");
+
+    // Defines are sorted before hashing, so insertion order must not matter.
+    EXPECT_EQ (a.toCacheKeyPayload(), b.toCacheKeyPayload());
+}
+
+TEST (TranspileOptionsTests, CacheKeyPayload_DefineValueAffectsKey)
+{
+    TranspileOptions a;
+    a.defines.set ("FOO", "1");
+
+    TranspileOptions b;
+    b.defines.set ("FOO", "2");
+
+    EXPECT_NE (a.toCacheKeyPayload(), b.toCacheKeyPayload());
 }


### PR DESCRIPTION
This pull request introduces significant enhancements and flexibility to the shader bundling and transpilation system, mainly focusing on improving the `yup_shader_bundler` tool and its integration with CMake. The changes add support for new command-line options, enable advanced SPIR-V compilation controls, and allow for more complex shader bundle configurations, including multi-stage pipelines and custom include paths.

**Key changes include:**

### Shader Bundler Tool Enhancements

* Refactored `yup_shader_bundler` to support multiple pipeline stages (vertex, fragment, compute, etc.) via a new `--stage <stage> <path>` option, and improved CLI usage documentation. Also added support for specifying source and target languages, SPIR-V options, preprocessor defines, and include directories. [[1]](diffhunk://#diff-b0e72ad548f07e97bb82eaf485fef88520e34e334efae3692e6315eda3381f69L184-R225) [[2]](diffhunk://#diff-b0e72ad548f07e97bb82eaf485fef88520e34e334efae3692e6315eda3381f69L220-R420) [[3]](diffhunk://#diff-b0e72ad548f07e97bb82eaf485fef88520e34e334efae3692e6315eda3381f69R75-R88)
* Implemented the `getPrefixedValues` helper to collect `-D` and `-I` style flags for preprocessor defines and include paths.

### SPIR-V Compilation Controls

* Introduced a new `SpvOptimizationMode` enum and corresponding `spirvOptimization` field in `TranspileOptions`, enabling explicit control over SPIR-V optimization (none, size, performance), validation, and debug info emission. Updated the transpiler to use these options. [[1]](diffhunk://#diff-7f4d43dec73a5d6b9dc14e0ddd2257b03ad452e979f855da9bab4d71b322f2bfR27-R35) [[2]](diffhunk://#diff-7f4d43dec73a5d6b9dc14e0ddd2257b03ad452e979f855da9bab4d71b322f2bfL49-R72) [[3]](diffhunk://#diff-0f828db84e03b2e75c2abe2a4a4fa87ae26f666ddb3f69e9bf8a5223b5d037aaL1083-R1120)
* Added support for passing include search paths to the GLSL parser, enabling `#include` resolution during shader compilation. [[1]](diffhunk://#diff-0f828db84e03b2e75c2abe2a4a4fa87ae26f666ddb3f69e9bf8a5223b5d037aaL1056-R1074) [[2]](diffhunk://#diff-7f4d43dec73a5d6b9dc14e0ddd2257b03ad452e979f855da9bab4d71b322f2bfL49-R72)

### CMake Integration Improvements

* Enhanced the `yup_add_shader_bundle()` CMake helper to accept an `OPTIONS` argument, allowing arbitrary flags to be forwarded to `yup_shader_bundler` (e.g., `--spirv-opt`, `--target-langs`, `-D`, `-I`). Updated documentation accordingly. [[1]](diffhunk://#diff-649e5d6078cf92373f5bfae39b62772fec41a4da5e41a8966dc64cf2b856a8f8L91-R95) [[2]](diffhunk://#diff-649e5d6078cf92373f5bfae39b62772fec41a4da5e41a8966dc64cf2b856a8f8L102-R106) [[3]](diffhunk://#diff-649e5d6078cf92373f5bfae39b62772fec41a4da5e41a8966dc64cf2b856a8f8L142-R147)
* Updated the main logic to support the new CLI options and improved detection of compile mode invocation.

### Internal Consistency

* Updated all internal uses of `TranspileOptions` to use the new `spirvOptimization` field instead of the old `spirvOptimize` boolean.

These changes collectively make the shader bundling pipeline more robust, configurable, and suitable for advanced rendering workflows.