### PR TITLE
Rename eigen to eigen_library

### DIFF
--- a/modules/yup_audio_devices/native/yup_CoreAudio_mac.cpp
+++ b/modules/yup_audio_devices/native/yup_CoreAudio_mac.cpp
@@ -130,7 +130,7 @@ struct IgnoreUnused
 template <typename T>
 static auto getDataPtrAndSize (T& t)
 {
-    static_assert (std::is_pod_v<T>);
+    static_assert (std::is_standard_layout_v<T>);
     return std::make_tuple (&t, (UInt32) sizeof (T));
 }
 

--- a/modules/yup_simd/types/yup_EigenAdapters.h
+++ b/modules/yup_simd/types/yup_EigenAdapters.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#if YUP_MODULE_AVAILABLE_eigen
+#if YUP_MODULE_AVAILABLE_eigen_library
 
 namespace yup
 {

--- a/modules/yup_simd/yup_simd.h
+++ b/modules/yup_simd/yup_simd.h
@@ -128,8 +128,8 @@
 #endif
 
 //==============================================================================
-#if YUP_MODULE_AVAILABLE_eigen
-#include <eigen/eigen.h>
+#if YUP_MODULE_AVAILABLE_eigen_library
+#include <eigen_library/eigen_library.h>
 #endif
 
 //==============================================================================
@@ -149,7 +149,7 @@ YUP_BEGIN_IGNORE_WARNINGS_MSVC (4661)
 #include "buffers/yup_AffineTransformOperations.h"
 #include "buffers/yup_ColorVectorOperations.h"
 
-#if YUP_MODULE_AVAILABLE_eigen
+#if YUP_MODULE_AVAILABLE_eigen_library
 #include "types/yup_EigenAdapters.h"
 #endif
 

--- a/thirdparty/bungee_library/bungee_library.h
+++ b/thirdparty/bungee_library/bungee_library.h
@@ -32,7 +32,7 @@
     website:          https://github.com/mackron/dr_libs
     license:          MPL2.0
 
-    dependencies:     pffft_library eigen
+    dependencies:     pffft_library eigen_library
     searchpaths:      upstream
     defines:          BUNGEE_USE_PFFFT=1 BUNGEE_VERSION="2.4.8"
 

--- a/thirdparty/eigen_library/eigen_library.h
+++ b/thirdparty/eigen_library/eigen_library.h
@@ -24,7 +24,7 @@
 
   BEGIN_YUP_MODULE_DECLARATION
 
-    ID:               eigen
+    ID:               eigen_library
     vendor:           eigen
     version:          5.0.1
     name:             Eigen C++ template library for linear algebra


### PR DESCRIPTION
This pull request updates the handling and naming of the Eigen library integration throughout the codebase, ensuring consistency and clarity in module references. Additionally, it updates a type trait in a static assertion to improve standards compliance.

Key changes include:

**Eigen Library Integration and Naming Consistency:**

* Renamed the Eigen module from `eigen` to `eigen_library` in the module declaration and updated all references accordingly, including in `thirdparty/eigen_library/eigen_library.h` [[1]](diffhunk://#diff-1085cd5e6c6c35aa60fae2f8a3c085d61653c06e372a01a8ccace60c30e948c2L27-R27) `modules/yup_simd/yup_simd.h` [[2]](diffhunk://#diff-d9b97bad0290ac2a4e5e1857fe8ae0c65ef6984e95f63bb5e7335f07cbb57104L131-R132) [[3]](diffhunk://#diff-d9b97bad0290ac2a4e5e1857fe8ae0c65ef6984e95f63bb5e7335f07cbb57104L152-R152) `modules/yup_simd/types/yup_EigenAdapters.h` [[4]](diffhunk://#diff-3357722ce5fd3af7e59b6277cc39de9758318b4524dc00ef3ef3c15e66ae500bL24-R24) and `thirdparty/bungee_library/bungee_library.h` [[5]](diffhunk://#diff-ea16eeec44ed386a1932609796049393aba78a687037421a4a12f353a4aebf25L35-R35).

**Code Standards and Type Safety:**

* Changed the static assertion in `getDataPtrAndSize` from `std::is_pod_v<T>` to `std::is_standard_layout_v<T>` for improved standards compliance and compatibility with non-POD, standard-layout types (`modules/yup_audio_devices/native/yup_CoreAudio_mac.cpp`).