### PR TITLE
Separate build folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Build System
 
+- justfile recipes now use per-platform build directories (`build/mac`, `build/ios`, `build/android`, `build/emscripten`, `build/ninja`, `build/win`), so switching platforms no longer requires `just clean` and preserves downloaded FetchContent dependencies per platform. The `just build` recipe gains a `PLATFORM` parameter (default `mac`).
 - `yup_standalone_app` gains a `MAXIMUM_MEMORY` Emscripten argument (`-sMAXIMUM_MEMORY`); when set it caps the heap that `ALLOW_MEMORY_GROWTH` may reach.
 - `yup_tests` wasm build: raised `INITIAL_MEMORY` to 256 MB, added `MAXIMUM_MEMORY` cap of 1 GB, and reduced `STACK_SIZE` to 1 MB to give the heap room for concurrent pthread stress tests; fixes `RuntimeError: memory access out of bounds` in CI.
 - Fetched third-party dependencies (SDL3, Perfetto, plugin SDKs) are now cloned shallowly (`--depth 1`) and skip network update checks on reconfigure, speeding up fresh configures and reconfigures. Shallow cloning is automatically disabled when a `GIT_TAG` is a commit hash.

--- a/justfile
+++ b/justfile
@@ -6,37 +6,42 @@ gtest_filter := "*"
 default:
   @just --list
 
+[confirm("Are you sure you want to clean the build/{{PLATFORM}} folder? [y/N]")]
+[doc("clean single platform build artifacts")]
+clean PLATFORM="mac":
+  rm -Rf build/{{PLATFORM}}/*
+
 [confirm("Are you sure you want to clean the build folder? [y/N]")]
 [doc("clean project build artifacts")]
-clean:
+cleanall:
   rm -Rf build/*
 
 [doc("build project using cmake")]
-build CONFIG="Debug" TARGET="yup_tests":
-  cmake --build build --config {{CONFIG}} --target {{TARGET}}
+build PLATFORM="mac" CONFIG="Debug" TARGET="yup_tests":
+  cmake --build build/{{PLATFORM}} --config {{CONFIG}} --target {{TARGET}}
 
 [doc("execute unit tests using cmake")]
 [macos]
 test CONFIG="Debug":
-  cmake -G Xcode -B build
-  cmake --build build --target yup_tests --config {{CONFIG}}
-  build/tests/{{CONFIG}}/yup_tests.app/Contents/MacOS/yup_tests --gtest_filter={{gtest_filter}}
+  cmake -G Xcode -B build/mac
+  cmake --build build/mac --target yup_tests --config {{CONFIG}}
+  build/mac/tests/{{CONFIG}}/yup_tests.app/Contents/MacOS/yup_tests --gtest_filter={{gtest_filter}}
 
 [doc("generate and open project in macOS using Xcode")]
 [macos]
 mac PROFILING="OFF":
-  cmake -G Xcode -B build -DYUP_ENABLE_PROFILING={{PROFILING}}
-  -open build/yup.xcodeproj
+  cmake -G Xcode -B build/mac -DYUP_ENABLE_PROFILING={{PROFILING}}
+  -open build/mac/yup.xcodeproj
 
 [doc("generate and open project using Ninja multi config")]
 ninja PROFILING="OFF":
-  cmake -G "Ninja Multi-Config" -B build -DYUP_ENABLE_PROFILING={{PROFILING}}
+  cmake -G "Ninja Multi-Config" -B build/ninja -DYUP_ENABLE_PROFILING={{PROFILING}}
 
 [doc("generate and open project in Windows using Visual Studio")]
 [windows]
 win PROFILING="OFF":
-  cmake -G "Visual Studio 18 2026" -B build -DYUP_ENABLE_PROFILING={{PROFILING}}
-  -start build/yup.slnx
+  cmake -G "Visual Studio 18 2026" -B build/win -DYUP_ENABLE_PROFILING={{PROFILING}}
+  -start build/win/yup.slnx
 
 [doc("generate project in Linux using Ninja")]
 [linux]
@@ -45,41 +50,41 @@ linux PROFILING="OFF":
 
 [doc("generate and open project for iOS using Xcode")]
 [macos]
-ios PLATFORM="OS64":
-  cmake -G Xcode -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/ios.cmake -DPLATFORM={{PLATFORM}}
-  -open build/yup.xcodeproj
+ios IOS_PLATFORM="OS64":
+  cmake -G Xcode -B build/ios -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/ios.cmake -DPLATFORM={{IOS_PLATFORM}}
+  -open build/ios/yup.xcodeproj
 
 [doc("generate and open project for iOS Simulator macOS using Xcode")]
 [macos]
-ios_simulator PLATFORM="SIMULATORARM64":
-  @just ios {{PLATFORM}}
+ios_simulator IOS_PLATFORM="SIMULATORARM64":
+  @just ios {{IOS_PLATFORM}}
 
 [doc("generate and open project for Android using Android Studio (macos)")]
 [macos]
 android:
-  cmake -G Xcode -B build -DYUP_TARGET_ANDROID=ON
-  -open -a /Applications/Android\ Studio.app build/examples/graphics
+  cmake -G Xcode -B build/android -DYUP_TARGET_ANDROID=ON
+  -open -a /Applications/Android\ Studio.app build/android/examples/graphics
 
 [doc("generate and open project for Android using Android Studio (windows)")]
 [windows]
 android:
-  cmake -G "Visual Studio 18 2026" -B build -DYUP_TARGET_ANDROID=ON
+  cmake -G "Visual Studio 18 2026" -B build/android -DYUP_TARGET_ANDROID=ON
 
 [doc("generate and open project for Android using Android Studio (linux)")]
 [linux]
 android:
-  cmake -G "Unix Makefiles" -B build -DYUP_TARGET_ANDROID=ON
+  cmake -G "Unix Makefiles" -B build/android -DYUP_TARGET_ANDROID=ON
 
 [doc("generate and build project for WASM")]
 emscripten CONFIG="Debug" TARGET="yup_tests":
   emcc -v
-  emcmake cmake -G "Ninja Multi-Config" -B build
-  @just build {{CONFIG}} {{TARGET}}
+  emcmake cmake -G "Ninja Multi-Config" -B build/emscripten
+  @just build emscripten {{CONFIG}} {{TARGET}}
 
 [doc("run tests for WASM")]
-[working-directory: 'build/tests/Debug/']
+[working-directory: 'build/emscripten/tests/Debug/']
 emscripten_test:
-  @just build Debug
+  @just build emscripten Debug
   node yup_tests.js --gtest_filter={{gtest_filter}}
 
 [doc("serve project for WASM")]


### PR DESCRIPTION
This pull request updates the build system to use per-platform build directories and improves the `justfile` recipes for better platform isolation and ease of use. The main changes are the introduction of platform-specific build folders, parameterization of build commands, and updates to clean and test commands to work with the new structure.

**Build system improvements:**

* All `justfile` build and project generation recipes now use per-platform build directories (e.g., `build/mac`, `build/ios`, `build/android`, `build/emscripten`, `build/ninja`, `build/win`). This means switching platforms doesn't require a full clean and preserves downloaded dependencies per platform. The `just build` recipe now accepts a `PLATFORM` parameter (default `mac`). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR53) [[2]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R9-R44)
* Added `clean PLATFORM` to remove build artifacts for a single platform, and renamed the old `clean` to `cleanall` for removing all build artifacts.

**Recipe and parameter updates:**

* All build, test, and project generation recipes in `justfile` have been updated to use the appropriate platform-specific build directory and parameters (e.g., `build/mac`, `build/ios`, `build/android`, etc.). [[1]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R9-R44) [[2]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L48-R87)
* The `emscripten` and `emscripten_test` recipes now use the `build/emscripten` directory and pass the correct platform argument to the build command.

These changes make the build process more robust and efficient, especially when working with multiple platforms.