### PR TITLE
CancelToken and CancelSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Core
 
 - Added a `YAML` class: a self-contained YAML parser and writer converting between YAML text and `var` (`parse`, `fromString`, `toString`, `writeToStream`, `FormatOptions`), with core-schema type resolution, block/flow collections, block scalars, and anchors/aliases/merge keys
+- Added a `CancelToken` class (`threads/yup_CancelToken.h`): a thread-safe, copyable observer token with `wasCancelled()`, blocking observation via `waitForCancellation()`, and callback observation via `registerCallback()`/`Registration`, inspired by .NET's `CancellationToken`
+- Added a `CancelTokenSource` class (`threads/yup_CancelTokenSource.h`): a move-only RAII owner of a `CancelToken` that is the sole canceller, requesting cancellation automatically when destroyed (unless moved-from), with observer copies obtained via `getToken()`
 
 ### Graphics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Core
 
 - Added a `YAML` class: a self-contained YAML parser and writer converting between YAML text and `var` (`parse`, `fromString`, `toString`, `writeToStream`, `FormatOptions`), with core-schema type resolution, block/flow collections, block scalars, and anchors/aliases/merge keys
-- Added a `CancelToken` class (`threads/yup_CancelToken.h`): a thread-safe, copyable observer token with `wasCancelled()`, blocking observation via `waitForCancellation()`, and callback observation via `registerCallback()`/`Registration`, inspired by .NET's `CancellationToken`
+- Added a `CancelToken` class (`threads/yup_CancelToken.h`): a thread-safe, copyable observer token with `wasCancelled()`, blocking observation via `waitForCancellation()`, and callback observation via `registerCallback()`/`Registration`
 - Added a `CancelTokenSource` class (`threads/yup_CancelTokenSource.h`): a move-only RAII owner of a `CancelToken` that is the sole canceller, requesting cancellation automatically when destroyed (unless moved-from), with observer copies obtained via `getToken()`
 
 ### Graphics

--- a/docs/multithreading/cancellation.md
+++ b/docs/multithreading/cancellation.md
@@ -2,8 +2,7 @@
 
 `yup::CancelToken` and `yup::CancelTokenSource` (in `yup_core/threads`) provide
 a thread-safe way to request and observe the cancellation of a long-running
-operation, loosely inspired by .NET's
-`CancellationTokenSource`/`CancellationToken` and `std::jthread`.
+operation.
 
 ## Requesting cancellation
 

--- a/docs/multithreading/cancellation.md
+++ b/docs/multithreading/cancellation.md
@@ -1,0 +1,91 @@
+# Cancellation
+
+`yup::CancelToken` and `yup::CancelTokenSource` (in `yup_core/threads`) provide
+a thread-safe way to request and observe the cancellation of a long-running
+operation, loosely inspired by .NET's
+`CancellationTokenSource`/`CancellationToken` and `std::jthread`.
+
+## Requesting cancellation
+
+`CancelTokenSource` is the only thing that can request cancellation, and it
+does so either explicitly via `cancel()` or automatically when it is destroyed
+(unless it has been moved-from). `CancelToken` is an observer-only handle that
+shares the source's cancellation state; all copies of a token observe the same
+cancellation:
+
+```cpp
+yup::CancelTokenSource source;
+auto token = source.getToken(); // observer handle
+
+// ... hand `token` to worker threads or sub-operations ...
+
+source.cancel(); // visible via token.wasCancelled()
+```
+
+The source is move-only (like `std::jthread`): moving it transfers ownership,
+and the moved-from source no longer cancels on destruction. When the source
+goes out of scope, the token is cancelled automatically - no manual cleanup
+needed:
+
+```cpp
+yup::CancelToken token;
+{
+    yup::CancelTokenSource source;
+    token = source.getToken(); // start a long-running operation
+} // source destroyed -> token cancelled
+```
+
+## Observing cancellation
+
+The three complementary ways to observe cancellation can be mixed freely:
+
+- **Poll** - `wasCancelled()` is a lock-free atomic read that never blocks and
+  performs no allocation, so it is safe on any thread, including real-time
+  threads.
+
+- **Block** - `waitForCancellation (timeoutMs)` suspends the calling thread
+  until the token is cancelled (or the timeout expires). Because the
+  underlying event is manual-reset, any number of threads can wait
+  concurrently and all of them wake up on cancellation:
+
+  ```cpp
+  if (token.waitForCancellation (5000))
+      cleanup();
+  ```
+
+- **Callback** - `registerCallback (cb)` invokes `cb` exactly once, on the
+  thread that cancels the source, in registration order. If the token is
+  already cancelled, `cb` runs synchronously inside `registerCallback()`. The
+  returned `Registration` handle keeps the callback registered; destroying it
+  (or calling `unregister()`) removes the callback so a future cancellation
+  will not invoke it:
+
+  ```cpp
+  auto registration = token.registerCallback ([] { cleanup(); });
+
+  // later: registration.unregister();
+  ```
+
+## Non-cancellable tokens
+
+Tokens created with the default constructor or with `CancelToken::none()` can
+never be cancelled; all of them compare equal. `wasCancelled()` always returns
+false for them, `waitForCancellation()` returns false immediately, and
+registered callbacks are never invoked. A cancellable token can only be
+obtained from a live `CancelTokenSource`.
+
+## Thread-safety guarantees
+
+- `CancelTokenSource::cancel()`, `CancelToken::wasCancelled()`,
+  `waitForCancellation()`, `registerCallback()` and
+  `Registration::unregister()` are safe to call concurrently from any number
+  of threads.
+- Each registered callback is invoked at most once.
+- `wasCancelled()` never blocks and performs no allocation.
+- Callbacks must not block and must not throw; a throwing callback is caught
+  and asserted without preventing the remaining callbacks from running.
+- `unregister()` guarantees the callback will not be invoked by a *future*
+  cancellation. A callback already captured by an in-flight cancellation may
+  still run once after `unregister()` returns.
+- Cancellation triggered by a source's destructor runs on the destroying
+  thread, so callbacks run in whatever context the source is destroyed in.

--- a/docs/multithreading/index.md
+++ b/docs/multithreading/index.md
@@ -19,3 +19,5 @@ audio-thread safety are still to come.
 - **Synchronization** - `CriticalSection`, atomics, and lock-free patterns for
   the audio thread.
 - **Async** - timers, async updaters, and deferred callbacks.
+- **Cancellation** - `CancelToken`: request, block on, and observe operation
+  cancellation.

--- a/modules/yup_core/threads/yup_CancelToken.cpp
+++ b/modules/yup_core/threads/yup_CancelToken.cpp
@@ -1,0 +1,205 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+struct CancelToken::State
+{
+    std::atomic<bool> cancelled { false };
+
+    CriticalSection callbacksLock;
+    std::vector<std::pair<uint64, std::function<void()>>> callbacks;
+    uint64 nextCallbackId = 0;
+
+    WaitableEvent cancelEvent { true };
+
+    void requestCancellation() noexcept
+    {
+        const bool wasAlreadyCancelled = cancelled.exchange (true);
+        cancelEvent.signal();
+
+        if (! wasAlreadyCancelled)
+        {
+            std::vector<std::function<void()>> toInvoke;
+
+            {
+                const ScopedLock sl (callbacksLock);
+
+                toInvoke.reserve (callbacks.size());
+
+                for (auto& callback : callbacks)
+                    toInvoke.push_back (std::move (callback.second));
+
+                callbacks.clear();
+            }
+
+            for (auto& callback : toInvoke)
+            {
+                try
+                {
+                    callback();
+                }
+                catch (...)
+                {
+                    // Your callbacks must not throw exceptions!
+                    jassertfalse;
+                }
+            }
+        }
+    }
+};
+
+//==============================================================================
+CancelToken::~CancelToken() = default;
+
+CancelToken& CancelToken::operator= (const CancelToken&) = default;
+
+CancelToken& CancelToken::operator= (CancelToken&&) noexcept = default;
+
+//==============================================================================
+CancelToken::Registration::~Registration()
+{
+    unregister();
+}
+
+CancelToken::Registration& CancelToken::Registration::operator= (Registration&& other) noexcept
+{
+    if (this != &other)
+    {
+        unregister();
+
+        state = std::move (other.state);
+        callbackId = std::exchange (other.callbackId, 0);
+    }
+
+    return *this;
+}
+
+CancelToken::Registration::Registration (Registration&& other) noexcept
+    : state (std::move (other.state))
+    , callbackId (std::exchange (other.callbackId, 0))
+{
+}
+
+CancelToken::Registration::Registration (std::shared_ptr<State> stateToHold, uint64 callbackIdToHold) noexcept
+    : state (std::move (stateToHold))
+    , callbackId (callbackIdToHold)
+{
+}
+
+void CancelToken::Registration::unregister() noexcept
+{
+    if (auto s = state)
+    {
+        const ScopedLock sl (s->callbacksLock);
+
+        for (auto it = s->callbacks.begin(); it != s->callbacks.end(); ++it)
+        {
+            if (it->first == callbackId)
+            {
+                s->callbacks.erase (it);
+                break;
+            }
+        }
+    }
+
+    state.reset();
+    callbackId = 0;
+}
+
+bool CancelToken::Registration::isValid() const noexcept
+{
+    return state != nullptr;
+}
+
+//==============================================================================
+CancelToken::CancelToken (std::shared_ptr<State> stateToHold) noexcept
+    : state (std::move (stateToHold))
+{
+}
+
+bool CancelToken::wasCancelled() const noexcept
+{
+    auto s = state;
+    return s != nullptr && s->cancelled.load();
+}
+
+bool CancelToken::isCancellable() const noexcept
+{
+    return state != nullptr;
+}
+
+CancelToken CancelToken::none()
+{
+    return CancelToken (nullptr);
+}
+
+bool CancelToken::waitForCancellation (int timeOutMilliseconds) const
+{
+    auto s = state;
+    return s != nullptr && s->cancelEvent.wait (timeOutMilliseconds);
+}
+
+CancelToken::Registration CancelToken::registerCallback (std::function<void()> callback)
+{
+    auto s = state;
+
+    if (s == nullptr)
+        return Registration {};
+
+    {
+        const ScopedLock sl (s->callbacksLock);
+
+        if (! s->cancelled.load())
+        {
+            const auto id = s->nextCallbackId++;
+            s->callbacks.emplace_back (id, std::move (callback));
+
+            return Registration (std::move (s), id);
+        }
+    }
+
+    try
+    {
+        callback();
+    }
+    catch (...)
+    {
+        // Your callbacks must not throw exceptions!
+        jassertfalse;
+    }
+
+    return Registration {};
+}
+
+bool CancelToken::operator== (const CancelToken& other) const noexcept
+{
+    return state == other.state;
+}
+
+bool CancelToken::operator!= (const CancelToken& other) const noexcept
+{
+    return state != other.state;
+}
+
+} // namespace yup

--- a/modules/yup_core/threads/yup_CancelToken.h
+++ b/modules/yup_core/threads/yup_CancelToken.h
@@ -45,11 +45,9 @@ namespace yup
     All copies of a CancelToken share the same underlying cancellation state,
     so a cancellation requested by the source is immediately visible to every
     copy. Tokens can be handed to worker threads or asynchronous sub-operations
-    freely; no token copy can ever trigger cancellation itself, mirroring
-    .NET's CancellationToken.
+    freely; no token copy can ever trigger cancellation itself.
 
-    The token can be observed in three complementary ways, loosely inspired by
-    the .NET cancellation model:
+    The token can be observed in three complementary ways:
 
       - Non-blocking polling: wasCancelled() is a lock-free atomic read that
         can be checked from any thread, including real-time threads.
@@ -60,8 +58,7 @@ namespace yup
       - Callbacks: registerCallback() attaches a callback that is invoked
         exactly once, on the thread that cancels the token, in registration
         order. A callback registered after the token was already cancelled is
-        invoked synchronously by registerCallback(), mirroring .NET's
-        CancellationToken.Register().
+        invoked synchronously by registerCallback().
 
     Tokens that can never be cancelled can be created with the default
     constructor or with none(); calling waitForCancellation() on such a token
@@ -253,7 +250,7 @@ public:
 
         If the token has already been cancelled, the callback is invoked
         synchronously by this method, before it returns, and the returned
-        registration is invalid (mirroring .NET's CancellationToken.Register()).
+        registration is invalid.
 
         If the token can never be cancelled (default-constructed / none()),
         the callback is never invoked and the returned registration is invalid.

--- a/modules/yup_core/threads/yup_CancelToken.h
+++ b/modules/yup_core/threads/yup_CancelToken.h
@@ -1,0 +1,296 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace yup
+{
+
+//==============================================================================
+/**
+    A copyable, thread-safe *observer* token used to observe the cancellation
+    of a long-running operation.
+
+    CancelToken itself is observer-only: it can never request cancellation.
+    Cancellation is requested through a CancelTokenSource, which owns the
+    cancellation state and cancels it either explicitly via
+    CancelTokenSource::cancel() or automatically when the source is destroyed.
+    Tokens obtained from a source via CancelTokenSource::getToken() observe
+    that cancellation.
+
+    All copies of a CancelToken share the same underlying cancellation state,
+    so a cancellation requested by the source is immediately visible to every
+    copy. Tokens can be handed to worker threads or asynchronous sub-operations
+    freely; no token copy can ever trigger cancellation itself, mirroring
+    .NET's CancellationToken.
+
+    The token can be observed in three complementary ways, loosely inspired by
+    the .NET cancellation model:
+
+      - Non-blocking polling: wasCancelled() is a lock-free atomic read that
+        can be checked from any thread, including real-time threads.
+
+      - Blocking wait: waitForCancellation() suspends the caller until the
+        token is cancelled, or a timeout expires.
+
+      - Callbacks: registerCallback() attaches a callback that is invoked
+        exactly once, on the thread that cancels the token, in registration
+        order. A callback registered after the token was already cancelled is
+        invoked synchronously by registerCallback(), mirroring .NET's
+        CancellationToken.Register().
+
+    Tokens that can never be cancelled can be created with the default
+    constructor or with none(); calling waitForCancellation() on such a token
+    returns false immediately and registered callbacks are never invoked.
+
+    This class is header-light and wasCancelled() performs no allocation, so it
+    is safe to use on hot paths.
+
+    @see CancelTokenSource
+
+    @tags{Core}
+*/
+class YUP_API CancelToken
+{
+private:
+    //==============================================================================
+    struct State;
+
+public:
+    //==============================================================================
+    /** A handle to a registered cancellation callback.
+
+        Returned by CancelToken::registerCallback(). The callback remains
+        registered while this object is alive; destroying it (or calling
+        unregister()) removes the callback so it will not be invoked by any
+        future cancellation.
+
+        This class is move-only: copies would make unregistration ambiguous, so
+        they are disabled.
+
+        @see CancelToken::registerCallback
+    */
+    class YUP_API Registration
+    {
+    public:
+        //==============================================================================
+        /** Creates an empty registration that is not attached to any token. */
+        Registration() = default;
+
+        /** Destructor.
+
+            If this registration is still attached to a token, the callback is
+            unregistered before the handle is destroyed.
+
+            @see unregister
+        */
+        ~Registration();
+
+        /** Moves another registration's state into this one, releasing any
+            callback this object currently owns.
+        */
+        Registration& operator= (Registration&& other) noexcept;
+
+        /** Moves another registration's state into this one.
+
+            After the move, the source registration becomes invalid.
+        */
+        Registration (Registration&& other) noexcept;
+
+        //==============================================================================
+        /** Removes the associated callback from the token.
+
+            After this method returns, the callback will not be invoked by any
+            future cancellation. Note that if a cancellation was already in
+            progress and had captured this callback before unregister() ran,
+            that in-flight invocation may still complete.
+
+            Calling unregister() on an already-released registration is a
+            harmless no-op.
+
+            @see isValid
+        */
+        void unregister() noexcept;
+
+        /** Returns true if this registration is still attached to a token,
+            i.e. unregister() has not yet been called (or the state moved away).
+
+            @see unregister
+        */
+        bool isValid() const noexcept;
+
+    private:
+        friend class CancelToken;
+
+        Registration (std::shared_ptr<State> stateToHold, uint64 callbackIdToHold) noexcept;
+
+        std::shared_ptr<State> state;
+        uint64 callbackId = 0;
+
+        YUP_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (Registration)
+    };
+
+    //==============================================================================
+    /** Creates a token that can never be cancelled.
+
+        This is equivalent to none(). A cancellable token can only be obtained
+        from a CancelTokenSource via CancelTokenSource::getToken().
+
+        @see none, CancelTokenSource::getToken
+    */
+    CancelToken() = default;
+
+    /** Destructor. */
+    ~CancelToken();
+
+    /** Copies the token.
+
+        All copies share the same cancellation state, so a cancellation
+        requested by the token's CancelTokenSource is observed by all the
+        others.
+
+        @see wasCancelled
+    */
+    CancelToken (const CancelToken&) = default;
+
+    /** Moves the token.
+
+        After the move, the source token becomes non-cancellable (equivalent to
+        none()) while the destination keeps the shared cancellation state.
+    */
+    CancelToken (CancelToken&&) noexcept = default;
+
+    /** Replaces this token's state with a copy of another token's state. */
+    CancelToken& operator= (const CancelToken&);
+
+    /** Replaces this token's state with another token's state, leaving the
+        source token non-cancellable.
+    */
+    CancelToken& operator= (CancelToken&&) noexcept;
+
+    //==============================================================================
+    /** Returns a token that can never be cancelled.
+
+        This is equivalent to the default constructor. Calling
+        waitForCancellation() on such a token returns false immediately,
+        wasCancelled() always returns false and isCancellable() returns false.
+        All such tokens compare equal to each other.
+
+        @see isCancellable, CancelTokenSource
+    */
+    static CancelToken none();
+
+    //==============================================================================
+    /** Returns true if the token has been cancelled.
+
+        This happens when the token's CancelTokenSource has been cancelled or
+        destroyed. It is a lock-free atomic read, safe to call from any thread,
+        including real-time threads.
+
+        @see CancelTokenSource::cancel
+    */
+    bool wasCancelled() const noexcept;
+
+    /** Returns true if this token is linked to a cancellation state that can
+        still be cancelled, i.e. it was obtained from a live CancelTokenSource.
+
+        This is false for tokens created with the default constructor or with
+        none(), and for tokens that were moved-from.
+
+        @see CancelTokenSource::getToken, none
+    */
+    bool isCancellable() const noexcept;
+
+    //==============================================================================
+    /** Blocks the calling thread until the token is cancelled.
+
+        This uses a manual-reset waitable event, so if the token has already
+        been cancelled the method returns immediately, and any number of
+        threads can wait concurrently - all of them are woken up when the
+        token's CancelTokenSource is cancelled.
+
+        @param timeOutMilliseconds  the maximum time to wait, in milliseconds.
+                                    A negative value waits forever.
+
+        @returns    true if the token was cancelled; false if the timeout
+                    expired first, or if this token can never be cancelled
+                    (default-constructed / none() / moved-from).
+
+        @see wasCancelled, CancelTokenSource
+    */
+    bool waitForCancellation (int timeOutMilliseconds = -1) const;
+
+    //==============================================================================
+    /** Registers a callback to be invoked when the token is cancelled.
+
+        The callback will be invoked exactly once, on the thread that cancels
+        the token (i.e. the thread calling CancelTokenSource::cancel() or
+        destroying the source), and in the order the callbacks were registered.
+
+        If the token has already been cancelled, the callback is invoked
+        synchronously by this method, before it returns, and the returned
+        registration is invalid (mirroring .NET's CancellationToken.Register()).
+
+        If the token can never be cancelled (default-constructed / none()),
+        the callback is never invoked and the returned registration is invalid.
+
+        The callback must not be empty, must not block, and must not throw
+        exceptions - a throwing callback is caught and asserted, and does not
+        prevent the remaining callbacks from running.
+
+        @param callback    the function to invoke on cancellation
+
+        @returns    a move-only Registration handle. Keep it alive for as long
+                    as the callback should remain registered; destroying it
+                    (or calling Registration::unregister()) removes the
+                    callback so a future cancellation will not invoke it. Note
+                    that if a cancellation is already in progress and has
+                    captured this callback, it may still run once after
+                    unregister() returns.
+
+        @see Registration, CancelTokenSource
+    */
+    [[nodiscard]] Registration registerCallback (std::function<void()> callback);
+
+    //==============================================================================
+    /** Returns true if both tokens share the same underlying cancellation state. */
+    bool operator== (const CancelToken& other) const noexcept;
+
+    /** Returns true if the tokens do not share the same cancellation state. */
+    bool operator!= (const CancelToken& other) const noexcept;
+
+private:
+    friend class CancelTokenSource;
+
+    explicit CancelToken (std::shared_ptr<State> stateToHold) noexcept;
+
+    std::shared_ptr<State> state;
+
+    YUP_LEAK_DETECTOR (CancelToken)
+};
+
+} // namespace yup

--- a/modules/yup_core/threads/yup_CancelTokenSource.cpp
+++ b/modules/yup_core/threads/yup_CancelTokenSource.cpp
@@ -1,0 +1,76 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+namespace yup
+{
+
+//==============================================================================
+CancelTokenSource::CancelTokenSource()
+    : state (std::make_shared<CancelToken::State>())
+{
+}
+
+CancelTokenSource::~CancelTokenSource()
+{
+    if (state != nullptr)
+        state->requestCancellation();
+}
+
+CancelTokenSource::CancelTokenSource (CancelTokenSource&& other) noexcept
+    : state (std::move (other.state))
+{
+}
+
+CancelTokenSource& CancelTokenSource::operator= (CancelTokenSource&& other) noexcept
+{
+    if (this != &other)
+    {
+        if (state != nullptr)
+            state->requestCancellation();
+
+        state = std::move (other.state);
+    }
+
+    return *this;
+}
+
+void CancelTokenSource::cancel() noexcept
+{
+    if (state != nullptr)
+        state->requestCancellation();
+}
+
+CancelToken CancelTokenSource::getToken() const
+{
+    return CancelToken (state);
+}
+
+bool CancelTokenSource::wasCancelled() const noexcept
+{
+    return state != nullptr && state->cancelled.load();
+}
+
+bool CancelTokenSource::isCancellable() const noexcept
+{
+    return state != nullptr;
+}
+
+} // namespace yup

--- a/modules/yup_core/threads/yup_CancelTokenSource.h
+++ b/modules/yup_core/threads/yup_CancelTokenSource.h
@@ -1,0 +1,131 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+namespace yup
+{
+
+//==============================================================================
+/**
+    A move-only RAII owner of a CancelToken that requests cancellation of the
+    token when it is destroyed.
+
+    This is the cancelling counterpart to the observer-only CancelToken: create a
+    source where an operation is started, hand observer copies obtained from
+    getToken() to the worker threads or sub-operations, and when the source is
+    destroyed (e.g. the owning view, session or processor goes away) the token
+    is cancelled automatically - waking any waitForCancellation() waiters and
+    invoking any registered callbacks.
+
+    Cancellation can also be requested explicitly at any time with cancel().
+
+    The source is move-only: copies are disabled because two owners would make
+    the destruction semantics ambiguous. Moving transfers ownership: the
+    moved-from source becomes inert and does not cancel on destruction. Tokens
+    obtained from getToken() are plain observer CancelTokens and can never trigger
+    cancellation themselves.
+
+    @see CancelToken
+
+    @tags{Core}
+*/
+class YUP_API CancelTokenSource
+{
+public:
+    //==============================================================================
+    /** Creates a source that owns a fresh, cancellable token.
+
+        The token can be observed (and copied) through getToken(); when this
+        source is destroyed it will request cancellation of that token.
+
+        @see getToken
+    */
+    CancelTokenSource();
+
+    /** Destructor.
+
+        Requests cancellation of the owned token - waking up any threads
+        blocked in CancelToken::waitForCancellation() and invoking any
+        registered callbacks on the calling thread - unless this source has
+        been moved-from, in which case it does nothing.
+
+        @see cancel
+    */
+    ~CancelTokenSource();
+
+    /** Moves ownership of the token from another source into this one.
+
+        After the move the other source becomes inert: it no longer owns a
+        cancellable token and its destructor will not request cancellation.
+
+        @see getToken
+    */
+    CancelTokenSource (CancelTokenSource&&) noexcept;
+
+    /** Moves ownership from another source, first cancelling whatever token
+        this source currently owns.
+
+        @see cancel
+    */
+    CancelTokenSource& operator= (CancelTokenSource&&) noexcept;
+
+    //==============================================================================
+    /** Requests cancellation of the owned token.
+
+        This marks the token as cancelled and wakes up any threads blocked in
+        CancelToken::waitForCancellation(), invoking any registered callbacks
+        on the calling thread. It is idempotent and safe to call from any
+        thread; the destructor also calls it, so explicit cancellation is
+        optional.
+
+        @see wasCancelled, getToken
+    */
+    void cancel() noexcept;
+
+    /** Returns a copy of the owned token that can be observed and copied
+        freely.
+
+        The returned token shares the cancellation state with this source, so
+        it is cancelled when this source is cancelled or destroyed. Copies of
+        the returned token never trigger cancellation themselves.
+
+        @see cancel, wasCancelled
+    */
+    CancelToken getToken() const;
+
+    /** Returns true if the owned token has been cancelled. */
+    bool wasCancelled() const noexcept;
+
+    /** Returns true if this source still owns a cancellable token (i.e. it
+        has not been moved-from).
+
+        @see getToken
+    */
+    bool isCancellable() const noexcept;
+
+private:
+    std::shared_ptr<CancelToken::State> state;
+
+    YUP_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CancelTokenSource)
+};
+
+} // namespace yup

--- a/modules/yup_core/yup_core.cpp
+++ b/modules/yup_core/yup_core.cpp
@@ -328,6 +328,8 @@ extern char** environ;
 #include "native/yup_AndroidDocument_android.cpp"
 #include "threads/yup_HighResolutionTimer.cpp"
 #include "threads/yup_WaitableEvent.cpp"
+#include "threads/yup_CancelToken.cpp"
+#include "threads/yup_CancelTokenSource.cpp"
 #include "network/yup_URL.cpp"
 #include "network/yup_WebInputStream.cpp"
 #include "streams/yup_URLInputSource.cpp"

--- a/modules/yup_core/yup_core.h
+++ b/modules/yup_core/yup_core.h
@@ -366,6 +366,8 @@ YUP_END_IGNORE_WARNINGS_MSVC
 #include "threads/yup_Process.h"
 #include "threads/yup_SpinLock.h"
 #include "threads/yup_WaitableEvent.h"
+#include "threads/yup_CancelToken.h"
+#include "threads/yup_CancelTokenSource.h"
 #include "threads/yup_Thread.h"
 #include "threads/yup_RecursiveSpinLock.h"
 #include "threads/yup_HighResolutionTimer.h"

--- a/tests/yup_core.cpp
+++ b/tests/yup_core.cpp
@@ -27,6 +27,8 @@
 #include "yup_core/yup_Base64.cpp"
 #include "yup_core/yup_BigInteger.cpp"
 #include "yup_core/yup_BufferedInputStream.cpp"
+#include "yup_core/yup_CancelToken.cpp"
+#include "yup_core/yup_CancelTokenSource.cpp"
 #include "yup_core/yup_CharacterFunctions.cpp"
 #include "yup_core/yup_ChildProcess.cpp"
 #include "yup_core/yup_ConsoleApplication.cpp"

--- a/tests/yup_core/yup_CancelToken.cpp
+++ b/tests/yup_core/yup_CancelToken.cpp
@@ -1,0 +1,596 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include <gtest/gtest.h>
+
+#include <yup_core/yup_core.h>
+
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using namespace yup;
+
+TEST (CancelTokenTests, DefaultConstructedTokenIsNeverCancelledAndNotCancellable)
+{
+    CancelToken token;
+
+    EXPECT_FALSE (token.wasCancelled());
+    EXPECT_FALSE (token.isCancellable());
+    EXPECT_EQ (CancelToken::none(), token);
+}
+
+TEST (CancelTokenTests, NoneTokenIsNeverCancelledAndNotCancellable)
+{
+    auto token = CancelToken::none();
+
+    EXPECT_FALSE (token.isCancellable());
+    EXPECT_FALSE (token.wasCancelled());
+    EXPECT_FALSE (token.waitForCancellation (0));
+}
+
+TEST (CancelTokenTests, AllNoneTokensAreEqual)
+{
+    EXPECT_EQ (CancelToken::none(), CancelToken::none());
+    EXPECT_EQ (CancelToken::none(), CancelToken());
+}
+
+TEST (CancelTokenTests, EqualityComparesSharedState)
+{
+    CancelToken defaultTokenA;
+    CancelToken defaultTokenB;
+
+    // default-constructed tokens are all the same never-cancellable token
+    EXPECT_EQ (defaultTokenA, defaultTokenB);
+
+    CancelTokenSource sourceA;
+    CancelTokenSource sourceB;
+
+    auto tokenA = sourceA.getToken();
+    auto tokenB = sourceB.getToken();
+
+    EXPECT_NE (tokenA, tokenB);
+
+    auto tokenACopy = tokenA;
+
+    EXPECT_EQ (tokenA, tokenACopy);
+    EXPECT_TRUE (tokenA == tokenACopy);
+    EXPECT_TRUE (tokenA != tokenB);
+}
+
+TEST (CancelTokenTests, TokenFromSourceIsCancellableAndNotCancelled)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    EXPECT_TRUE (token.isCancellable());
+    EXPECT_FALSE (token.wasCancelled());
+}
+
+TEST (CancelTokenTests, MovedFromTokenIsNotCancellable)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    CancelToken destination (std::move (token));
+
+    EXPECT_FALSE (token.isCancellable());
+    EXPECT_TRUE (destination.isCancellable());
+
+    source.cancel();
+
+    EXPECT_TRUE (destination.wasCancelled());
+}
+
+TEST (CancelTokenTests, CopiesShareCancellationState)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+    auto copy = token;
+
+    source.cancel();
+
+    EXPECT_TRUE (token.wasCancelled());
+    EXPECT_TRUE (copy.wasCancelled());
+}
+
+TEST (CancelTokenTests, AssignmentSharesCancellationState)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    CancelToken other;
+    other = token;
+
+    source.cancel();
+
+    EXPECT_TRUE (other.wasCancelled());
+}
+
+TEST (CancelTokenTests, WaitForCancellationTimesOut)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    EXPECT_FALSE (token.waitForCancellation (50));
+    EXPECT_FALSE (token.wasCancelled());
+}
+
+TEST (CancelTokenTests, WaitForCancellationReturnsImmediatelyWhenAlreadyCancelled)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    source.cancel();
+
+    EXPECT_TRUE (token.waitForCancellation (0));
+}
+
+TEST (CancelTokenTests, WaitForCancellationUnblocksWhenCancelledFromAnotherThread)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    std::thread canceller ([&]
+    {
+        Thread::sleep (50);
+        source.cancel();
+    });
+
+    EXPECT_TRUE (token.waitForCancellation (2000));
+
+    canceller.join();
+
+    EXPECT_TRUE (token.wasCancelled());
+}
+
+TEST (CancelTokenTests, WaitForCancellationWakesMultipleWaiters)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    std::atomic<int> woken { 0 };
+    std::vector<std::thread> waiters;
+
+    for (int i = 0; i < 4; ++i)
+    {
+        waiters.emplace_back ([&]
+        {
+            if (token.waitForCancellation (2000))
+                ++woken;
+        });
+    }
+
+    Thread::sleep (50);
+    source.cancel();
+
+    for (auto& waiter : waiters)
+        waiter.join();
+
+    EXPECT_EQ (4, woken.load());
+}
+
+TEST (CancelTokenTests, CallbackIsInvokedOnCancel)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    std::atomic<int> callCount { 0 };
+
+    auto registration = token.registerCallback ([&]
+    {
+        ++callCount;
+    });
+
+    EXPECT_EQ (0, callCount.load());
+
+    source.cancel();
+
+    EXPECT_EQ (1, callCount.load());
+}
+
+TEST (CancelTokenTests, CallbackRegisteredAfterCancellationRunsImmediately)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    std::atomic<int> callCount { 0 };
+
+    source.cancel();
+
+    auto registration = token.registerCallback ([&]
+    {
+        ++callCount;
+    });
+
+    EXPECT_EQ (1, callCount.load());
+    EXPECT_FALSE (registration.isValid()); // already ran; nothing left to unregister
+}
+
+TEST (CancelTokenTests, CallbacksRunInRegistrationOrder)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    std::vector<int> order;
+    std::vector<CancelToken::Registration> registrations;
+
+    for (int i = 0; i < 5; ++i)
+        registrations.push_back (token.registerCallback ([&, i]
+        {
+            order.push_back (i);
+        }));
+
+    source.cancel();
+
+    EXPECT_EQ (std::vector<int> ({ 0, 1, 2, 3, 4 }), order);
+}
+
+TEST (CancelTokenTests, UnregisterPreventsCallbackInvocation)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    std::atomic<int> callCount { 0 };
+
+    auto registration = token.registerCallback ([&]
+    {
+        ++callCount;
+    });
+    registration.unregister();
+
+    EXPECT_FALSE (registration.isValid());
+
+    source.cancel();
+
+    EXPECT_EQ (0, callCount.load());
+}
+
+TEST (CancelTokenTests, RegistrationDestructorUnregisters)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    std::atomic<int> callCount { 0 };
+
+    {
+        auto registration = token.registerCallback ([&]
+        {
+            ++callCount;
+        });
+        EXPECT_TRUE (registration.isValid());
+    }
+
+    source.cancel();
+
+    EXPECT_EQ (0, callCount.load());
+}
+
+TEST (CancelTokenTests, RegistrationIsMoveable)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    std::atomic<int> callCount { 0 };
+
+    auto registration = token.registerCallback ([&]
+    {
+        ++callCount;
+    });
+    auto moved = std::move (registration);
+
+    EXPECT_FALSE (registration.isValid());
+    EXPECT_TRUE (moved.isValid());
+
+    source.cancel();
+
+    EXPECT_EQ (1, callCount.load());
+}
+
+TEST (CancelTokenTests, RegisteringOnNoneTokenIsNoOp)
+{
+    auto token = CancelToken::none();
+    std::atomic<int> callCount { 0 };
+
+    auto registration = token.registerCallback ([&]
+    {
+        ++callCount;
+    });
+
+    EXPECT_FALSE (registration.isValid());
+    EXPECT_EQ (0, callCount.load());
+
+    EXPECT_FALSE (token.wasCancelled());
+}
+
+TEST (CancelTokenTests, RegisteringOnDefaultTokenIsNoOp)
+{
+    CancelToken token;
+    std::atomic<int> callCount { 0 };
+
+    auto registration = token.registerCallback ([&]
+    {
+        ++callCount;
+    });
+
+    EXPECT_FALSE (registration.isValid());
+    EXPECT_EQ (0, callCount.load());
+}
+
+TEST (CancelTokenTests, ConcurrentRegisterUnregisterAndCancelIsDataRaceFree)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    constexpr int numThreads = 8;
+    constexpr int callbacksPerThread = 200;
+
+    std::atomic<int> mainCallbackCount { 0 };
+    auto mainRegistration = token.registerCallback ([&]
+    {
+        ++mainCallbackCount;
+    });
+
+    // Per-callback invocation counters, indexed as [thread * callbacksPerThread + index]
+    std::vector<std::atomic<int>> invocationCounts (static_cast<size_t> (numThreads * callbacksPerThread));
+
+    std::vector<std::vector<CancelToken::Registration>> keptRegistrations (static_cast<size_t> (numThreads));
+    std::vector<std::atomic<bool>> finished (static_cast<size_t> (numThreads));
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < numThreads; ++t)
+    {
+        threads.emplace_back ([&, t]
+        {
+            for (int i = 0; i < callbacksPerThread; ++i)
+            {
+                auto registration = token.registerCallback ([&, t, i]
+                {
+                    ++invocationCounts[static_cast<size_t> (t * callbacksPerThread + i)];
+                });
+
+                if (i % 3 == 0)
+                    registration.unregister(); // these must never fire
+                else
+                    keptRegistrations[static_cast<size_t> (t)].push_back (std::move (registration));
+            }
+
+            finished[static_cast<size_t> (t)] = true;
+        });
+    }
+
+    // Wait for every thread to finish registering before cancelling, so the
+    // expected per-callback counts are deterministic
+    const auto startTime = Time::getMillisecondCounter();
+
+    while (std::any_of (finished.begin(), finished.end(), [] (const auto& f)
+    {
+        return ! f.load();
+    }))
+    {
+        if (Time::getMillisecondCounter() - startTime > 5000)
+            FAIL() << "Timed out waiting for registration threads";
+
+        Thread::sleep (5);
+    }
+
+    source.cancel();
+
+    for (auto& thread : threads)
+        thread.join();
+
+    EXPECT_EQ (1, mainCallbackCount.load());
+
+    int totalInvocationCount = 0;
+
+    for (int t = 0; t < numThreads; ++t)
+    {
+        for (int i = 0; i < callbacksPerThread; ++i)
+        {
+            const auto count = invocationCounts[static_cast<size_t> (t * callbacksPerThread + i)].load();
+
+            if (i % 3 == 0)
+                EXPECT_EQ (0, count); // unregistered before cancel -> never invoked
+            else
+                EXPECT_EQ (1, count); // registered before cancel -> invoked exactly once
+
+            totalInvocationCount += count;
+        }
+    }
+
+    const int unregisteredPerThread = (callbacksPerThread + 2) / 3; // number of i in [0, N) with i % 3 == 0
+    const int keptPerThread = callbacksPerThread - unregisteredPerThread;
+
+    EXPECT_EQ (numThreads * keptPerThread, totalInvocationCount);
+}
+
+TEST (CancelTokenTests, ConcurrentCancellationFromMultipleThreadsInvokesCallbacksExactlyOnce)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    constexpr int numCallbacks = 100;
+    constexpr int numCancellers = 8;
+
+    std::vector<std::atomic<int>> callCounts (static_cast<size_t> (numCallbacks));
+    std::vector<CancelToken::Registration> registrations;
+
+    for (int i = 0; i < numCallbacks; ++i)
+        registrations.push_back (token.registerCallback ([&, i]
+        {
+            ++callCounts[static_cast<size_t> (i)];
+        }));
+
+    std::atomic<bool> start { false };
+    std::atomic<int> sawCancelled { 0 };
+    std::vector<std::thread> cancellers;
+
+    for (int t = 0; t < numCancellers; ++t)
+    {
+        cancellers.emplace_back ([&]
+        {
+            while (! start.load())
+                Thread::yield();
+
+            source.cancel(); // only the first of these may invoke the callbacks
+
+            if (token.wasCancelled())
+                ++sawCancelled;
+        });
+    }
+
+    start = true;
+
+    for (auto& canceller : cancellers)
+        canceller.join();
+
+    // every thread that requested cancellation observes the cancelled state
+    EXPECT_EQ (numCancellers, sawCancelled.load());
+
+    // exactly once, despite 8 concurrent cancellation requests
+    for (auto& count : callCounts)
+        EXPECT_EQ (1, count.load());
+}
+
+TEST (CancelTokenTests, CancellationRacingWithUnregistrationInvokesCallbacksAtMostOnce)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    constexpr int numThreads = 8;
+    constexpr int callbacksPerThread = 100;
+    constexpr int unregisterEvery = 3; // 1/3 of the registrations are unregistered while cancelling
+
+    std::vector<std::atomic<int>> callCounts (static_cast<size_t> (numThreads * callbacksPerThread));
+
+    std::vector<std::vector<CancelToken::Registration>> registrations (static_cast<size_t> (numThreads));
+    std::vector<std::atomic<bool>> ready (static_cast<size_t> (numThreads));
+    std::atomic<bool> go { false };
+    std::vector<std::thread> threads;
+
+    for (int t = 0; t < numThreads; ++t)
+    {
+        threads.emplace_back ([&, t]
+        {
+            // phase 1: register all callbacks
+            for (int i = 0; i < callbacksPerThread; ++i)
+                registrations[static_cast<size_t> (t)].push_back (token.registerCallback ([&, t, i]
+                {
+                    ++callCounts[static_cast<size_t> (t * callbacksPerThread + i)];
+                }));
+
+            ready[static_cast<size_t> (t)] = true;
+
+            // phase 2: unregister 1/3 of them, racing with the in-flight cancellation
+            while (! go.load())
+                Thread::yield();
+
+            for (int i = 0; i < callbacksPerThread; ++i)
+                if (i % unregisterEvery == 0)
+                    registrations[static_cast<size_t> (t)][static_cast<size_t> (i)].unregister();
+        });
+    }
+
+    // Wait for every callback to be registered before starting the race
+    const auto startTime = Time::getMillisecondCounter();
+
+    while (std::any_of (ready.begin(), ready.end(), [] (const auto& r)
+    {
+        return ! r.load();
+    }))
+    {
+        if (Time::getMillisecondCounter() - startTime > 5000)
+            FAIL() << "Timed out waiting for registration threads";
+
+        Thread::sleep (5);
+    }
+
+    std::thread canceller ([&]
+    {
+        while (! go.load())
+            Thread::yield();
+
+        source.cancel();
+    });
+
+    go = true;
+
+    canceller.join();
+
+    for (auto& thread : threads)
+        thread.join();
+
+    // A callback may be captured by the in-flight cancellation even after
+    // unregister() removed it, but it can never run more than once
+    for (auto& count : callCounts)
+        EXPECT_LE (count.load(), 1);
+}
+
+TEST (CancelTokenTests, ConcurrentCancellationWakesAllWaitingThreads)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    constexpr int numWaiters = 8;
+    constexpr int numCancellers = 4;
+
+    std::atomic<int> woken { 0 };
+    std::vector<std::thread> waiters;
+
+    for (int i = 0; i < numWaiters; ++i)
+    {
+        waiters.emplace_back ([&]
+        {
+            if (token.waitForCancellation (2000))
+                ++woken;
+        });
+    }
+
+    Thread::sleep (50); // let the waiters block on the event before cancelling
+
+    std::atomic<bool> start { false };
+    std::vector<std::thread> cancellers;
+
+    for (int t = 0; t < numCancellers; ++t)
+    {
+        cancellers.emplace_back ([&]
+        {
+            while (! start.load())
+                Thread::yield();
+
+            source.cancel();
+        });
+    }
+
+    start = true;
+
+    for (auto& canceller : cancellers)
+        canceller.join();
+
+    for (auto& waiter : waiters)
+        waiter.join();
+
+    // manual-reset semantics: all blocked waiters are woken, and any waiter
+    // that arrives after the cancellation still returns true immediately
+    EXPECT_EQ (numWaiters, woken.load());
+    EXPECT_TRUE (token.wasCancelled());
+}

--- a/tests/yup_core/yup_CancelTokenSource.cpp
+++ b/tests/yup_core/yup_CancelTokenSource.cpp
@@ -1,0 +1,179 @@
+/*
+  ==============================================================================
+
+   This file is part of the YUP library.
+   Copyright (c) 2026 - kunitoki@gmail.com
+
+   YUP is an open source library subject to open-source licensing.
+
+   The code included in this file is provided under the terms of the ISC license
+   http://www.isc.org/downloads/software-support-policy/isc-license. Permission
+   to use, copy, modify, and/or distribute this software for any purpose with or
+   without fee is hereby granted provided that the above copyright notice and
+   this permission notice appear in all copies.
+
+   YUP IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+  ==============================================================================
+*/
+
+#include <gtest/gtest.h>
+
+#include <yup_core/yup_core.h>
+
+#include <atomic>
+#include <thread>
+#include <type_traits>
+
+using namespace yup;
+
+TEST (CancelTokenSourceTests, DefaultConstructedSourceOwnsActiveToken)
+{
+    CancelTokenSource source;
+
+    EXPECT_TRUE (source.isCancellable());
+    EXPECT_FALSE (source.wasCancelled());
+    EXPECT_FALSE (source.getToken().wasCancelled());
+}
+
+TEST (CancelTokenSourceTests, SourceCancelsTokenOnDestruction)
+{
+    CancelToken token;
+
+    {
+        CancelTokenSource source;
+        token = source.getToken();
+
+        EXPECT_FALSE (token.wasCancelled());
+    }
+
+    EXPECT_TRUE (token.wasCancelled());
+}
+
+TEST (CancelTokenSourceTests, ExplicitCancelMarksTokenAndRemainsCancellable)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    source.cancel();
+
+    EXPECT_TRUE (token.wasCancelled());
+    EXPECT_TRUE (token.isCancellable());
+    EXPECT_TRUE (source.wasCancelled());
+    EXPECT_TRUE (source.isCancellable());
+
+    source.cancel(); // idempotent
+
+    EXPECT_TRUE (source.wasCancelled());
+}
+
+TEST (CancelTokenSourceTests, MovedFromSourceDoesNotCancelOnDestruction)
+{
+    CancelToken token;
+    CancelTokenSource destination;
+
+    {
+        CancelTokenSource source;
+        token = source.getToken();
+
+        destination = std::move (source); // transfer ownership
+
+        EXPECT_FALSE (source.isCancellable());
+        EXPECT_FALSE (source.wasCancelled());
+    } // moved-from `source` destroyed here — must not cancel
+
+    EXPECT_FALSE (token.wasCancelled());
+
+    destination.cancel(); // the owning source still controls the token
+
+    EXPECT_TRUE (token.wasCancelled());
+}
+
+TEST (CancelTokenSourceTests, MoveConstructionTransfersOwnershipAndCancelsOnDestruction)
+{
+    CancelToken token;
+
+    {
+        CancelTokenSource source;
+        token = source.getToken();
+
+        CancelTokenSource destination (std::move (source));
+
+        EXPECT_FALSE (source.isCancellable());
+        EXPECT_FALSE (token.wasCancelled());
+    } // `destination` destroyed here — cancels the token
+
+    EXPECT_TRUE (token.wasCancelled());
+}
+
+TEST (CancelTokenSourceTests, MoveAssignmentCancelsPreviouslyOwnedToken)
+{
+    CancelToken token;
+    CancelTokenSource source;
+    token = source.getToken();
+
+    CancelTokenSource other;
+    source = std::move (other);
+
+    // `source` was reassigned: the token it previously owned is cancelled
+    EXPECT_TRUE (token.wasCancelled());
+}
+
+TEST (CancelTokenSourceTests, SourceIsMoveOnly)
+{
+    static_assert (! std::is_copy_constructible_v<CancelTokenSource>);
+    static_assert (! std::is_copy_assignable_v<CancelTokenSource>);
+    static_assert (std::is_move_constructible_v<CancelTokenSource>);
+    static_assert (std::is_move_assignable_v<CancelTokenSource>);
+    static_assert (std::is_nothrow_move_constructible_v<CancelTokenSource>);
+    static_assert (std::is_nothrow_move_assignable_v<CancelTokenSource>);
+}
+
+TEST (CancelTokenSourceTests, GetTokenCopiesNeverTriggerCancellation)
+{
+    CancelTokenSource source;
+    auto token = source.getToken();
+
+    {
+        auto copy = token; // observer copy
+    } // destroyed — must not cancel anything
+
+    EXPECT_FALSE (token.wasCancelled());
+    EXPECT_FALSE (source.wasCancelled());
+}
+
+TEST (CancelTokenSourceTests, SourceDestructionWakesWaitersAndFiresCallbacks)
+{
+    CancelToken token;
+    std::atomic<int> callbackCount { 0 };
+    std::atomic<bool> woken { false };
+
+    std::thread waiter;
+    CancelToken::Registration registration;
+
+    {
+        CancelTokenSource source;
+        token = source.getToken();
+
+        registration = token.registerCallback ([&]
+        {
+            ++callbackCount;
+        });
+
+        waiter = std::thread ([&]
+        {
+            if (token.waitForCancellation (2000))
+                woken = true;
+        });
+
+        Thread::sleep (50);
+    } // source destroyed here — cancels, waking the waiter and firing the callback
+
+    waiter.join();
+
+    EXPECT_TRUE (woken.load());
+    EXPECT_EQ (1, callbackCount.load());
+    EXPECT_TRUE (token.wasCancelled());
+}


### PR DESCRIPTION
This pull request introduces a new thread-safe cancellation mechanism to the core library. It adds two new classes—`CancelToken` and `CancelTokenSource`—which allow long-running operations to be cancelled and observed safely across threads. The changes include full implementation, documentation, and integration into the multithreading module.

**New cancellation primitives:**

* Added a `CancelToken` class (`threads/yup_CancelToken.h`/`.cpp`): a copyable, thread-safe observer token for cancellation, supporting polling (`wasCancelled()`), blocking (`waitForCancellation()`), and callback observation (`registerCallback()` with `Registration` handles). [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR23-R24) [[2]](diffhunk://#diff-12fbf6b6fe87cde3b015122bc757f6c2f8c7e63684978dd5c374235682cf27a9R1-R296) [[3]](diffhunk://#diff-331ade35775615ad7b7a12f7be7a330c9fb89bb60c08463987d6c070477e929aR1-R205)
* Added a `CancelTokenSource` class (`threads/yup_CancelTokenSource.h`/`.cpp`): a move-only RAII owner of a cancellation state, which can request cancellation explicitly or automatically on destruction, and provides observer tokens via `getToken()`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR23-R24) [[2]](diffhunk://#diff-24a6bd4f0d88fe8fdc06eef7afb0b5c4ed66e8e2f145bfdbeff1f32f007fab46R1-R76)

**Documentation and integration:**

* Added a comprehensive guide to cancellation usage and guarantees in `docs/multithreading/cancellation.md`.
* Updated the multithreading module index to mention cancellation support.

**Changelog:**

* Updated `CHANGELOG.md` to document the addition of the cancellation primitives.